### PR TITLE
Create dev-M1.txt

### DIFF
--- a/.requirements/dev-M1.txt
+++ b/.requirements/dev-M1.txt
@@ -1,0 +1,8 @@
+deepdiff>=5.0
+gsutil>=4.60
+keras-tuner>=1.0.2
+matplotlib>=3.3
+pytest>=6.1.2
+questionary>=1.8.1
+scikit-learn>=0.24.1
+wandb>=0.12.1


### PR DESCRIPTION
# The solution in Mac system based on M1(ARM64)

## Issue

```zsh
(scope-env) user@user's MacBook-Pro scope-main % ./scope.py
zsh: illegal hardware instruction  ./scope.py
```

## Solution

In fact, the essence of the problem lies in tensorflow, a Python package.

We are supposed to install the correct version. Specifically, it should fit the ARM64 architecture, and the MacOs based on M1 CPU.

Apple official provides effective version. At this page `https://developer.apple.com/metal/tensorflow-plugin/` we can gain the methods to finish it.

But there are still some key things.

1. Anaconda doesn't work properly. In its place, We're going to use Miniforge3, also a conda environment, which is specifically adapted to Apple's operating system. Anaconda does not provide the correct version.

2. After we have successfully installed tensorflow-deps, tensorflow-macos, tensorflow-metal, we are going to modify the file `requirements.txt`before we install any other software. We are supposed to remove `tensorflow<2.6` `tensorflow-addons>=0.12` from `.ruquirements/dev.txt` .

   Then, we can use `pip install -r requirements.txt` to install other python packages.

   When we meet an error, we can install it by `conda install xxx` , and remove it from `.ruquirements/dev.txt` . After that, we use `pip install -r requirements.txt` again.

3. If some packages keep making errors.  We are supposed to update the conda environment.

## Specific operation
 To install the tensorflow for Mac OS 
```zsh
conda install -c apple tensorflow-deps
python -m pip install tensorflow-macos
python -m pip install tensorflow-metal
```

The `.requirements/dev-M1.txt`
```txt
deepdiff>=5.0
gsutil>=4.60
keras-tuner>=1.0.2
matplotlib>=3.3
pytest>=6.1.2
questionary>=1.8.1
scikit-learn>=0.24.1
wandb>=0.12.1
```

We need to install some packages separately.
```zsh
conda install numpy
conda install openblas #to fix the numpy
conda install healpy
conda install pandas
```