### PR TITLE
Improve source uploading and documentation

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -99,6 +99,12 @@ Make sure the requirements to run it are met, e.g.:
 pip install -r requirements.txt
 ```
 
+Ensure that Python can import from `scope` by modifying the `PYTHONPATH` environment variable, e.g. by adding the following to your `.bash_profile`:
+
+```bash
+export PYTHONPATH="$PYTHONPATH:$HOME/scope"
+```
+
 ### MacOS(ARM64)
 
 #### Tensorflow for Mac OS M1

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -75,7 +75,7 @@ process:
 3. get the classification of the objects in the dataset from Fritz
 4. append the classification to a new column on the dataset
 
-output: data with classifcation column appended.
+output: data with classification column appended.
 
 ```sh
 ./scope_download_classification.py -file sample.csv -group_ids [360] -token sample_token
@@ -94,7 +94,7 @@ process:
 1. get object ids of all the data from Fritz using the ra, dec, and period
 2. save the objects to Fritz group
 3. upload the classification of the objects in the dataset to target group on Fritz
-4. to avoid duplicate classification uploads in Fritz, use -classification ''
+4. duplicate classifications will not be uploaded to Fritz. Use the empty string to upload no classification.
 
 ```sh
 ./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification flaring -token sample_token

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -94,9 +94,10 @@ process:
 1. get object ids of all the data from Fritz using the ra, dec, and period
 2. save the objects to Fritz group
 3. upload the classification of the objects in the dataset to target group on Fritz
+4. to avoid duplicate classification uploads in Fritz, use -classification ''
 
 ```sh
-./scope_download_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification flaring -token sample_token
+./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification flaring -token sample_token
 ```
 
 ## Scope Upload Disagreements
@@ -114,5 +115,5 @@ process:
 6. upload the remaining disagreeing objects to target group on Fritz
 
 ```sh
-./scope_download_classification.py -file dataset.d15.csv -id 360 -token sample_token
+./scope_upload_disagreements.py -file dataset.d15.csv -id 360 -token sample_token
 ```

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -45,11 +45,15 @@ def upload_classification(
         else:
             # check which groups source is already in
             add_group_ids = group_ids.copy()
-            response = api("GET", f"/api/sources/{obj_id}/groups", args.token)
+            # response = api("GET", f"/api/sources/{obj_id}/groups", args.token)
+            response = api("GET", f"/api/sources/{obj_id}", args.token)
             data = response.json().get("data")
 
+            data_groups = data['groups']
+            data_classes = data['classifications']
+
             # remove existing groups from list of groups
-            for entry in data:
+            for entry in data_groups:
                 existing_group_id = entry['id']
                 if existing_group_id in add_group_ids:
                     add_group_ids.remove(existing_group_id)
@@ -59,8 +63,12 @@ def upload_classification(
                 json = {"objId": obj_id, "inviteGroupIds": add_group_ids}
                 response = api("POST", "/api/source_groups", args.token, json)
 
-        # allow classification assignment to be skipped (useful to avoid duplicates)
-        if classification != '':
+        # allow classification assignment to be skipped, check for duplicates
+        existing_classes = []
+        for entry in data_classes:
+            existing_classes += [entry['classification']]
+
+        if (classification != '') and (classification not in existing_classes):
             # upload classification
             json = {
                 "obj_id": obj_id,
@@ -70,7 +78,6 @@ def upload_classification(
                 "group_ids": group_ids,
             }
             response = api("POST", "/api/classification", args.token, json)
-            print(response.json())
 
 
 if __name__ == "__main__":

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
-import sys
 import argparse
 import json
 import pandas as pd
 from penquins import Kowalski
 from time import sleep
 from scope.fritz import save_newsource, api
-
-sys.path.append('../../scope')
 
 
 def upload_classification(
@@ -62,16 +59,18 @@ def upload_classification(
                 json = {"objId": obj_id, "inviteGroupIds": add_group_ids}
                 response = api("POST", "/api/source_groups", args.token, json)
 
-        # upload classification
-        # allow for multiple classifications at once?
-        json = {
-            "obj_id": obj_id,
-            "classification": classification,
-            "taxonomy_id": taxonomy_id,
-            "probability": prob,
-            "group_ids": group_ids,
-        }
-        response = api("POST", "/api/classification", args.token, json)
+        # allow classification assignment to be skipped (useful to avoid duplicates)
+        if classification != '':
+            # upload classification
+            json = {
+                "obj_id": obj_id,
+                "classification": classification,
+                "taxonomy_id": taxonomy_id,
+                "probability": prob,
+                "group_ids": group_ids,
+            }
+            response = api("POST", "/api/classification", args.token, json)
+            print(response.json())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added ability to upload no classification to Fritz, since duplicates easily arise (especially during testing). Also removed sys.path.append() in favor of adding scope directory to PYTHONPATH locally (now described in documentation). Other typo corrections in usage instructions.