### PR TITLE
Add multiple-classification uploads

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -83,21 +83,24 @@ output: data with classification column appended.
 
 ## Scope Upload Classification
 inputs:
-1. data containing ra, dec, period, and labels
-2. gloria object
-3. target group id on Fritz for upload
-4. Scope taxonomy id
-5. Class name of objects
-6. Fritz token
+0. gloria object (create a file named secrets.json with Kowalski username+password or token, host, port and protocol)
+1. CSV file containing ra, dec, period, and labels
+2. target group id(s) on Fritz for upload
+3. Scope taxonomy id
+4. Class name of objects. Set this to "read" and include taxonomy map to automatically upload multiple classes at once.
+5. Fritz token
+6. Taxonomy map ("label in file":"Fritz taxonomy name", JSON format).
+7. Comment to post (if specified)
 
 process:
 1. get object ids of all the data from Fritz using the ra, dec, and period
 2. save the objects to Fritz group
 3. upload the classification of the objects in the dataset to target group on Fritz
-4. duplicate classifications will not be uploaded to Fritz. Use the empty string to upload no classification.
+4. duplicate classifications will not be uploaded to Fritz. If n classifications are manually specified, probabilities will be sourced from the last n columns of the dataset.
+5. (post comment to each uploaded source)
 
 ```sh
-./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification flaring -token sample_token
+./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification variable flaring -token sample_token -taxonomy_map map.json -comment vetted
 ```
 
 ## Scope Upload Disagreements

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import argparse
-import json
+import json as JSON
 import pandas as pd
 from penquins import Kowalski
 from time import sleep
@@ -19,9 +19,45 @@ def upload_classification(
     :param classification: classified object (str)
     """
 
+    # get information from objects
     for index, row in file.iterrows():
-        # get information from objects
-        prob = row.iloc[-1]
+        probs = {}
+        cls_list = []
+        existing_classes = []
+
+        # for classification "read" mode, load taxonomy map
+        if classification is not None:
+            if (
+                (classification[0] == "read")
+                | (classification[0] == 'Read')
+                | (classification[0] == 'READ')
+            ):
+                with open(args.taxonomy_map, 'r') as f:
+                    taxonomy_map = JSON.load(f)
+
+                classes = [
+                    key for key in taxonomy_map.keys()
+                ]  # define list of columns to examine
+                row_classes = row[classes]  # limit current row to specific columns
+                nonzero_keys = row_classes.keys()[
+                    row_classes > 0
+                ]  # determine which dataset classifications are nonzero
+
+                for val in nonzero_keys:
+                    cls = taxonomy_map[val]
+                    if (
+                        cls != 'None'
+                    ):  # if Fritz taxonomy value exists, add to class list
+                        probs[cls] = row[val]
+                        cls_list += [cls]
+
+            else:
+                # for manual i classifications, use last i columns for probability
+                for i in range(len(classification)):
+                    cls = classification[i]
+                    cls_list += [cls]
+                    probs[cls] = row.iloc[-1 * len(classification) + i]
+
         ra, dec, period = float(row.ra), float(row.dec), float(row.period)
 
         # get object id
@@ -40,12 +76,12 @@ def upload_classification(
             obj_id = save_newsource(
                 gloria, group_ids, ra, dec, args.token, period=period, return_id=True
             )
-
+            data_groups = []
+            data_classes = []
         # save existing source
         else:
             # check which groups source is already in
             add_group_ids = group_ids.copy()
-            # response = api("GET", f"/api/sources/{obj_id}/groups", args.token)
             response = api("GET", f"/api/sources/{obj_id}", args.token)
             data = response.json().get("data")
 
@@ -63,40 +99,84 @@ def upload_classification(
                 json = {"objId": obj_id, "inviteGroupIds": add_group_ids}
                 response = api("POST", "/api/source_groups", args.token, json)
 
-        # allow classification assignment to be skipped, check for duplicates
-        existing_classes = []
-        for entry in data_classes:
-            existing_classes += [entry['classification']]
+            # check for existing classifications
+            for entry in data_classes:
+                existing_classes += [entry['classification']]
 
-        if (classification != '') and (classification not in existing_classes):
-            # upload classification
-            json = {
-                "obj_id": obj_id,
-                "classification": classification,
-                "taxonomy_id": taxonomy_id,
-                "probability": prob,
-                "group_ids": group_ids,
-            }
-            response = api("POST", "/api/classification", args.token, json)
+        # allow classification assignment to be skipped
+        if classification is not None:
+            for cls in cls_list:
+                if cls not in existing_classes:
+                    prob = probs[cls]
+                    # post all non-duplicate classifications
+                    json = {
+                        "obj_id": obj_id,
+                        "classification": cls,
+                        "taxonomy_id": taxonomy_id,
+                        "probability": prob,
+                        "group_ids": group_ids,
+                    }
+                    response = api("POST", "/api/classification", args.token, json)
+
+        if args.comment is not None:
+            # get comment text
+            response_comments = api(
+                "GET", f"/api/sources/{obj_id}/comments", args.token
+            )
+            data_comments = response_comments.json().get("data")
+
+            # check for existing comments
+            existing_comments = []
+            for entry in data_comments:
+                existing_comments += [entry['text']]
+
+            # post all non-duplicate comments
+            if args.comment not in existing_comments:
+                json = {
+                    "text": args.comment,
+                }
+                response = api(
+                    "POST", f"/api/sources/{obj_id}/comments", args.token, json
+                )
 
 
 if __name__ == "__main__":
     # setup connection to gloria to get the lightcurves
     # secrets file requires Kowalski username/password or token, host, port, and protocol
     with open('secrets.json', 'r') as f:
-        secrets = json.load(f)
+        secrets = JSON.load(f)
     gloria = Kowalski(**secrets['gloria'], verbose=False)
 
     # pass Fritz token as command line argument
     parser = argparse.ArgumentParser()
     parser.add_argument("-file", help="dataset")
     parser.add_argument("-group_ids", type=int, nargs='+', help="list of group ids")
-    parser.add_argument("-taxonomy_id", type=int, help="Fritz scope taxonomy id")
-    parser.add_argument("-classification", type=str, help="name of object class")
+    parser.add_argument(
+        "-taxonomy_id",
+        type=int,
+        nargs='?',
+        default=9,
+        const=9,
+        help="Fritz scope taxonomy id",
+    )
+    # parser.add_argument("-classification", type=str, help="name of object class")
+    parser.add_argument(
+        "-classification", type=str, nargs='+', help="list of object classes"
+    )
     parser.add_argument(
         "-token",
         type=str,
         help="put your Fritz token here. You can get it from your Fritz profile page",
+    )
+    parser.add_argument(
+        "-taxonomy_map",
+        type=str,
+        help="JSON file mapping between origin labels and Fritz taxonomy",
+    )
+    parser.add_argument(
+        "-comment",
+        type=str,
+        help="Post specified string to comments for sources in file",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR adds the functionality for scope_upload_classification.py to upload multiple classifications to Fritz at once. In this mode of use, the mapping of source dataset labels to Fritz taxonomy is provided by the user as a JSON file. The code checks existing classifications to avoid uploading duplicates. There is also a new option to upload a comment for each source in the input file. usage.md has been updated to reflect this new functionality.