### PR TITLE
Improve classification downloads

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -64,21 +64,21 @@ done;
 
 ## Scope Download Classification
 inputs:
-1. data containing ra, dec, and period
+1. CSV file containing obj_id and/or ra dec coordinates. Set to "parse" to download sources by group id.
 2. gloria object
-3. group id on Fritz
+3. target group id(s) on Fritz for download (if CSV file not provided)
 4. Fritz token
 
 process:
-1. get object ids of all the data from Fritz using the ra, dec, and period
-2. save the objects to Fritz group
-3. get the classification of the objects in the dataset from Fritz
-4. append the classification to a new column on the dataset
+1. if CSV file provided, query by object ids or ra, dec
+2. if CSV file not provided, query based on group id(s)
+3. get the classification/probabilities/periods of the objects in the dataset from Fritz
+4. append these values as new columns on the dataset, save to new file
 
-output: data with classification column appended.
+output: data with new columns appended.
 
 ```sh
-./scope_download_classification.py -file sample.csv -group_ids [360] -token sample_token
+./scope_download_classification.py -file sample.csv -group_ids 360 361 -token sample_token
 ```
 
 ## Scope Upload Classification

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -1,71 +1,129 @@
+#!/usr/bin/env python
 import argparse
-import csv
-import json
+import json as JSON
 import pandas as pd
 from penquins import Kowalski
 from time import sleep
-from scope.fritz import save_newsource, api
+from scope.fritz import api
+import warnings
 
 
-def download_classification(file, gloria, group_ids):
+def download_classification(file: str, gloria, group_ids: list, token: str):
     """
-    Upload labels to Fritz
-    :param file: file containing labels (csv)
+    Download labels from Fritz
+    :param file: CSV file containing obj_id column or "all" (str)
     :param gloria: Gloria object
-    :param group_ids: group id on Fritz for upload target location (list)
+    :param group_ids: group id on Fritz for download target location (list)
     """
-    # create new empty classification column
-    file["classification"] = pd.NaT
 
-    for index, row in file.iterrows():
-        if index > 5:
-            break
-        # get information from objects
-        ra, dec, period = float(row.ra), float(row.dec), float(row.period)
+    # read in CSV file
+    sources = pd.read_csv(file)
+    columns = sources.columns
 
-        # get object id
-        response = api(
-            "GET", f"/api/sources?&ra={ra}&dec={dec}&radius={2/3600}", args.token
-        )
-        sleep(0.9)
-        data = response.json().get("data")
-        obj_id = None
-        if data["totalMatches"] > 0:
-            obj_id = data["sources"][0]["id"]
+    # create new empty columns
+    sources["classification"] = None
+    sources["probability"] = None
+    sources["period_origin"] = None
+    sources["period"] = None
+    # add obj_id column if not passed in
+    if 'obj_id' not in columns:
+        sources["obj_id"] = None
+        search_by_obj_id = False
+    else:
+        search_by_obj_id = True
+
+    for index, row in sources.iterrows():
+        # query objects, starting with obj_id
+        data = []
+        if search_by_obj_id:
+            obj_id = row.obj_id
+            response = api("GET", '/api/sources/%s' % obj_id, token)
+            sleep(0.9)
+            data = response.json().get("data")
+            if len(data) == 0:
+                warnings.warn('No results from obj_id search - querying by ra/dec.')
+
+        # continue with coordinate search if obj_id unsuccsessful
+        if len(data) == 0:
+            if ('ra' in columns) & ('dec' in columns):
+                # query by ra/dec to get object id
+                ra, dec = row.ra, row.dec
+                response = api(
+                    "GET", f"/api/sources?&ra={ra}&dec={dec}&radius={2/3600}", token
+                )
+                sleep(0.9)
+                data = response.json().get("data")
+                obj_id = None
+                if data["totalMatches"] > 0:
+                    obj_id = data["sources"][0]["id"]
+                    sources.at[index, 'obj_id'] = obj_id
+            else:
+                raise KeyError(
+                    'Attemped to search by coordinates, but unable to find ra and dec columns.'
+                )
+
         print(f"object {index} id:", obj_id)
 
-        # save new source
-        if obj_id is None:
-            obj_id = save_newsource(
-                gloria, group_ids, ra, dec, period=period, return_id=True
-            )
+        # if successful search, get and save labels/probabilities/period annotations to sources dataframe
+        if obj_id is not None:
+            response = api("GET", f"/api/sources/{obj_id}/classifications", token)
+            data = response.json().get("data")
 
-        # save existing source
+            annot_response = api(
+                "GET", f'/api/sources/{obj_id}/annotations', token
+            ).json()
+            data_annot = annot_response.get('data')
+
+            cls_list = ''
+            prb_list = ''
+            for entry in data:
+                cls = entry['classification']
+                prb = entry['probability']
+                cls_list += cls + ';'  # same format as download from Fritz frontend
+                prb_list += str(prb) + ';'
+            cls_list = cls_list[:-1]  # remove trailing semicolon
+            prb_list = prb_list[:-1]
+
+            # loop through annotations, checking for periods
+            origin_list = ''
+            period_list = ''
+            for entry in data_annot:
+                annot_origin = entry['origin']
+                annot_data = entry['data']
+
+                annot_name = [x for x in annot_data.keys()][0]
+                annot_value = [x for x in annot_data.values()][0]
+
+                # if period is found, add to list
+                if annot_name == 'period':
+                    origin_list += annot_origin + ';'
+                    period_list += str(annot_value) + ';'
+            origin_list = origin_list[:-1]
+            period_list = period_list[:-1]
+
+            # store to new columns
+            sources.at[index, 'classification'] = cls_list
+            sources.at[index, 'probability'] = prb_list
+            sources.at[index, 'period_origin'] = origin_list
+            sources.at[index, 'period'] = period_list
+            sources.to_csv(file, index=False)
+
         else:
-            # save to group_id
-            json = {"objId": obj_id, "inviteGroupIds": group_ids}
-            response = api("POST", "/api/source_groups", args.token, json)
+            warnings.warn(f'Unable to find source {index} on Fritz.')
 
-        # get classificaiton
-        response = api("GET", f"/api/sources/{obj_id}/classifications", args.token)
-        data = response.json().get("data")
-
-        # store to new column
-        file.at[index, 'classification'] = data[0]["classification"]
-
-    return file
+    return sources
 
 
 if __name__ == "__main__":
     # setup connection to gloria to get the lightcurves
     with open('secrets.json', 'r') as f:
-        secrets = json.load(f)
+        secrets = JSON.load(f)
     gloria = Kowalski(**secrets['gloria'], verbose=False)
 
     # pass Fritz token as command line argument
     parser = argparse.ArgumentParser()
     parser.add_argument("-file", help="dataset")
-    parser.add_argument("-group_ids", help="list of group ids")
+    parser.add_argument("-group_ids", type=int, nargs='+', help="list of group ids")
     parser.add_argument(
         "-token",
         type=str,
@@ -73,10 +131,5 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # read in file to csv
-    with open(args.file) as f:
-        data = csv.reader(f)
-        sample = pd.DataFrame(data)
-
     # download object classifications in the file
-    download_classification(sample, gloria, args.group_ids)
+    download_classification(args.file, gloria, args.group_ids, args.token)

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -14,11 +14,13 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
     Download labels from Fritz
     :param file: CSV file containing obj_id column or "parse" to query by group ids (str)
     :param gloria: Gloria object
-    :param group_ids: group ids on Fritz for download target location (list)
+    :param group_ids: target group ids on Fritz for download (list)
     :param token: Fritz token (str)
     """
 
     if (file == "parse") | (file == 'Parse') | (file == 'PARSE'):
+        if group_ids is None:
+            raise ValueError('Specify group_ids to query Fritz.')
         response = api("GET", "/api/sources", token, {"group_ids": group_ids})
         source_data = response.json().get("data")
 
@@ -36,7 +38,10 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
                 "GET",
                 '/api/sources',
                 token,
-                {"group_ids": group_ids, 'pageNumber': pageNum + 1},
+                {
+                    "group_ids": group_ids,
+                    'pageNumber': pageNum + 1,
+                },  # page numbers start at 1
             )
             page_data = page_response.json().get('data')
             for src in page_data['sources']:

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -106,7 +106,11 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
             sources.at[index, 'probability'] = prb_list
             sources.at[index, 'period_origin'] = origin_list
             sources.at[index, 'period'] = period_list
-            sources.to_csv(file, index=False)
+
+            filename = (
+                file.removesuffix('.csv') + '_fritzDownload' + '.csv'
+            )  # rename updated file
+            sources.to_csv(filename, index=False)
 
         else:
             warnings.warn(f'Unable to find source {index} on Fritz.')

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -18,7 +18,7 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
     :param token: Fritz token (str)
     """
 
-    if (file == "parse") | (file == 'Parse') | (file == 'PARSE'):
+    if file in ["parse", 'Parse', 'PARSE']:
         if group_ids is None:
             raise ValueError('Specify group_ids to query Fritz.')
         response = api("GET", "/api/sources", token, {"group_ids": group_ids})


### PR DESCRIPTION
This PR improves the scope_download_classification.py tool. The user can provide a CSV file of object ids and/or ra-dec coordinates to query sources. There is also a "parse" option that queries all sources in a given group(s) without requiring an input file. In each case, the script creates a new CSV file containing each source's classifications, probabilities, and period annotations. The format of the classification column matches the output obtained from a download using the Fritz interface.