### PR TITLE
Increase group source download speed

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -68,17 +68,18 @@ inputs:
 2. gloria object
 3. target group id(s) on Fritz for download (if CSV file not provided)
 4. Fritz token
+5. Index or page number (if in "parse" mode) to begin downloading (optional)
 
 process:
 1. if CSV file provided, query by object ids or ra, dec
-2. if CSV file not provided, query based on group id(s)
+2. if CSV file not provided, bulk query based on group id(s)
 3. get the classification/probabilities/periods of the objects in the dataset from Fritz
 4. append these values as new columns on the dataset, save to new file
 
 output: data with new columns appended.
 
 ```sh
-./scope_download_classification.py -file sample.csv -group_ids 360 361 -token sample_token
+./scope_download_classification.py -file sample.csv -group_ids 360 361 -token sample_token -start 10
 ```
 
 ## Scope Upload Classification

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -3,10 +3,52 @@ import argparse
 import json as JSON
 import pandas as pd
 from penquins import Kowalski
-from time import sleep
+
+# from time import sleep
 from scope.fritz import api
 import warnings
 import numpy as np
+
+NUM_PER_PAGE = 500
+
+
+def organize_source_data(src):
+    id = src['id']
+    ra = src['ra']
+    dec = src['dec']
+
+    data_classes = src['classifications']
+    cls_list = ''
+    prb_list = ''
+    for entry in data_classes:
+        cls = entry['classification']
+        prb = entry['probability']
+        cls_list += cls + ';'  # same format as download from Fritz frontend
+        prb_list += str(prb) + ';'
+
+    cls_list = cls_list[:-1]  # remove trailing semicolon
+    prb_list = prb_list[:-1]
+
+    # loop through annotations, checking for periods
+    data_annot = src['annotations']
+    origin_list = ''
+    period_list = ''
+    for entry in data_annot:
+        annot_origin = entry['origin']
+        annot_data = entry['data']
+
+        annot_name = [x for x in annot_data.keys()][0]
+        annot_value = [x for x in annot_data.values()][0]
+
+        # if period is found, add to list
+        if annot_name == 'period':
+            origin_list += annot_origin + ';'
+            period_list += str(annot_value) + ';'
+
+    origin_list = origin_list[:-1]
+    period_list = period_list[:-1]
+
+    return id, ra, dec, cls_list, prb_list, origin_list, period_list
 
 
 def download_classification(file: str, gloria, group_ids: list, token: str):
@@ -18,10 +60,23 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
     :param token: Fritz token (str)
     """
 
+    ids = []
+    ras = []
+    decs = []
+    classes = []
+    probs = []
+    period_origins = []
+    periods = []
+
     if file in ["parse", 'Parse', 'PARSE']:
         if group_ids is None:
             raise ValueError('Specify group_ids to query Fritz.')
-        response = api("GET", "/api/sources", token, {"group_ids": group_ids})
+        response = api(
+            "GET",
+            "/api/sources",
+            token,
+            {"group_ids": group_ids, "numPerPage": NUM_PER_PAGE},
+        )
         source_data = response.json().get("data")
 
         # determine number of pages
@@ -29,29 +84,57 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
         nPerPage = source_data['numPerPage']
         pages = int(np.ceil(allMatches / nPerPage))
 
-        ids = []
-        ras = []
-        decs = []
         # iterate over all pages in results
         for pageNum in range(pages):
+            print(f'Page {pageNum + 1} of {pages}')
             page_response = api(
                 "GET",
                 '/api/sources',
                 token,
                 {
                     "group_ids": group_ids,
+                    'numPerPage': NUM_PER_PAGE,
                     'pageNumber': pageNum + 1,
                 },  # page numbers start at 1
             )
             page_data = page_response.json().get('data')
             for src in page_data['sources']:
+                (
+                    id,
+                    ra,
+                    dec,
+                    cls_list,
+                    prb_list,
+                    origin_list,
+                    period_list,
+                ) = organize_source_data(src)
+
                 ids += [src['id']]
                 ras += [src['ra']]
                 decs += [src['dec']]
+                classes += [cls_list]
+                probs += [prb_list]
+                period_origins += [origin_list]
+                periods += [period_list]
 
         # create dataframe from query results
-        sources = pd.DataFrame({'obj_id': ids, 'ra': ras, 'dec': decs})
-        print(f'Downloading {len(sources)} sources.')
+        sources = pd.DataFrame(
+            {
+                'obj_id': ids,
+                'ra': ras,
+                'dec': decs,
+                'classification': classes,
+                'probability': probs,
+                'period_origin': period_origins,
+                'period': periods,
+            }
+        )
+        filename = (
+            file.removesuffix('.csv') + '_fritzDownload_new' + '.csv'
+        )  # rename updated file
+        sources.to_csv(filename, index=False)
+        return
+        # print(f'Downloading {len(sources)} sources.')
     else:
         # read in CSV file
         sources = pd.read_csv(file)
@@ -76,10 +159,12 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
         if search_by_obj_id:
             obj_id = row.obj_id
             response = api("GET", '/api/sources/%s' % obj_id, token)
-            sleep(0.9)
+            # sleep(0.9)
             data = response.json().get("data")
             if len(data) == 0:
                 warnings.warn('No results from obj_id search - querying by ra/dec.')
+            else:
+                src = data
 
         # continue with coordinate search if obj_id unsuccsessful
         if len(data) == 0:
@@ -89,11 +174,12 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
                 response = api(
                     "GET", f"/api/sources?&ra={ra}&dec={dec}&radius={2/3600}", token
                 )
-                sleep(0.9)
+                # sleep(0.9)
                 data = response.json().get("data")
                 obj_id = None
                 if data["totalMatches"] > 0:
-                    obj_id = data["sources"][0]["id"]
+                    src = data["sources"][0]
+                    obj_id = src["id"]
                     sources.at[index, 'obj_id'] = obj_id
             else:
                 raise KeyError(
@@ -104,42 +190,29 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
 
         # if successful search, get and save labels/probabilities/period annotations to sources dataframe
         if obj_id is not None:
-            response = api("GET", f"/api/sources/{obj_id}/classifications", token)
-            data = response.json().get("data")
 
-            annot_response = api(
-                "GET", f'/api/sources/{obj_id}/annotations', token
-            ).json()
-            data_annot = annot_response.get('data')
+            # response = api("GET", f"/api/sources/{obj_id}/classifications", token)
+            # data = response.json().get("data")
 
-            cls_list = ''
-            prb_list = ''
-            for entry in data:
-                cls = entry['classification']
-                prb = entry['probability']
-                cls_list += cls + ';'  # same format as download from Fritz frontend
-                prb_list += str(prb) + ';'
-            cls_list = cls_list[:-1]  # remove trailing semicolon
-            prb_list = prb_list[:-1]
+            # annot_response = api(
+            #    "GET", f'/api/sources/{obj_id}/annotations', token
+            # ).json()
+            # data_annot = annot_response.get('data')
 
-            # loop through annotations, checking for periods
-            origin_list = ''
-            period_list = ''
-            for entry in data_annot:
-                annot_origin = entry['origin']
-                annot_data = entry['data']
-
-                annot_name = [x for x in annot_data.keys()][0]
-                annot_value = [x for x in annot_data.values()][0]
-
-                # if period is found, add to list
-                if annot_name == 'period':
-                    origin_list += annot_origin + ';'
-                    period_list += str(annot_value) + ';'
-            origin_list = origin_list[:-1]
-            period_list = period_list[:-1]
+            (
+                id,
+                ra,
+                dec,
+                cls_list,
+                prb_list,
+                origin_list,
+                period_list,
+            ) = organize_source_data(src)
 
             # store to new columns
+            # sources.at[index, 'id'] = id
+            sources.at[index, 'ra'] = ra
+            sources.at[index, 'dec'] = dec
             sources.at[index, 'classification'] = cls_list
             sources.at[index, 'probability'] = prb_list
             sources.at[index, 'period_origin'] = origin_list

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -10,6 +10,7 @@ import warnings
 import numpy as np
 
 NUM_PER_PAGE = 500
+CHECKPOINT_NUM = 500
 
 
 def organize_source_data(src):
@@ -138,6 +139,7 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
     else:
         # read in CSV file
         sources = pd.read_csv(file)
+        filename = file.removesuffix('.csv') + '_fritzDownload' + '.csv'  # rename file
 
     columns = sources.columns
 
@@ -209,6 +211,14 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
                 period_list,
             ) = organize_source_data(src)
 
+            # ids += [id]
+            # ras += [ra]
+            # decs += [dec]
+            # classes += [cls_list]
+            # probs += [prb_list]
+            # period_origins += [origin_list]
+            # periods += [period_list]
+
             # store to new columns
             # sources.at[index, 'id'] = id
             sources.at[index, 'ra'] = ra
@@ -218,13 +228,23 @@ def download_classification(file: str, gloria, group_ids: list, token: str):
             sources.at[index, 'period_origin'] = origin_list
             sources.at[index, 'period'] = period_list
 
-            filename = (
-                file.removesuffix('.csv') + '_fritzDownload' + '.csv'
-            )  # rename updated file
-            sources.to_csv(filename, index=False)
+            # sources['ra'] = ras
+            # sources['dec'] = decs
+            # sources['classification'] = classes
+            # sources['probability'] = probs
+            # sources['period_origin'] = period_origins
+            # sources['period'] = periods
+
+            # occasional checkpoint at specified number of sources
+            if (index + 1) % CHECKPOINT_NUM == 0:
+                print(f'Saving checkpoint at index {index}.')
+                sources.to_csv(filename, index=False)
 
         else:
             warnings.warn(f'Unable to find source {index} on Fritz.')
+
+        # final save
+        sources.to_csv(filename, index=False)
 
     return sources
 


### PR DESCRIPTION
This PR speeds up group source downloads by eliminating unneeded API calls. If -file is set to 'parse', a download of ~2500 sources completes in ~3 minutes. There remains the option to download specific sources, but this process still loops over each source and takes longer. The new code also adds checkpoints to save results periodically and allows intermediate resumption in the case of an interrupted download.