### PR TITLE
Overhaul taxonomy upload script

### DIFF
--- a/tools/taxonomy.py
+++ b/tools/taxonomy.py
@@ -26,6 +26,7 @@ def post(
     provenance: Optional[str] = None,
 ):
     """Post taxonomy to Fritz
+       NOTE: token in config.yaml must have 'Post taxonomy' permission
 
     $ ./taxonomy.py \
       --taxonomy='phenomenological.yaml' \

--- a/tools/taxonomy.py
+++ b/tools/taxonomy.py
@@ -84,6 +84,14 @@ def post(
     )
     print(response.json())
 
+    response_json = response.json()
+    if response_json['status'] == 'success':
+        tax_id = response_json['data']['taxonomy_id']
+        print(f'Posted taxonomy (ID = {tax_id}.)')
+    else:
+        message = response_json['message']
+        print(f'Did not post taxonomy - message: {message}.')
+
 
 if __name__ == "__main__":
     fire.Fire(post)

--- a/tools/taxonomy.py
+++ b/tools/taxonomy.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python
 import fire
 import pathlib
 import requests
 from typing import List, Optional
 import yaml
+from inspect import ismodule
 
 
 config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
@@ -10,36 +12,74 @@ with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
 
 
-def fritz_api(method: str, endpoint: str, data: Optional[dict]):
+def fritz_api(method: str, endpoint: str, data: Optional[dict] = None):
     headers = {"Authorization": f"token {config['fritz']['token']}"}
     response = requests.request(method, endpoint, json=data, headers=headers)
     return response
 
 
-def post(taxonomy: str, group_ids: Optional[List[int]] = None):
+def post(
+    taxonomy,
+    group_ids: Optional[List[int]] = None,
+    name: Optional[str] = None,
+    version: Optional[str] = None,
+    provenance: Optional[str] = None,
+):
     """Post taxonomy to Fritz
 
-    $ python tools/taxonomy.py \
-      --taxonomy=tools/scope_taxonomy.yaml \
-      --group_id=339
+    $ ./taxonomy.py \
+      --taxonomy='phenomenological.yaml' \
+      --group_ids=1444 \
+      --name='Scope Phenomenological Taxonomy' \
+      --version='1.2.0' \
+      --provenance='https://github.com/bfhealy/scope-phenomenology.git'
 
-    :param taxonomy: path to yaml file with taxonomy in tdtax format
+    $ ./taxonomy.py \
+      --taxonomy=scope_phenom \
+      --group_ids=339
+
+    :param taxonomy: path to yaml file with taxonomy in tdtax format, or imported taxonomy module
     :param group_ids: ids of groups on Fritz to post taxonomy to.
-                      if None, will post to all user (token) groups
+                      if None, will post to all user (token) groups (int or list)
+    :param name: name of input taxonomy (str)
+    :param version: version of input taxonomy (str)
+    :param provenance: URL hosting input taxonomy (str)
     :return:
     """
-    with open(taxonomy) as taxonomy_yaml:
-        tax = yaml.load(taxonomy_yaml, Loader=yaml.FullLoader)
+
+    # Read .yaml file and check other arguments
+    if type(taxonomy) == str:
+        with open(taxonomy) as taxonomy_yaml:
+            tax = yaml.load(taxonomy_yaml, Loader=yaml.FullLoader)
+        if (name is None) | (version is None) | (provenance is None):
+            raise ValueError('Must specify name, version and provenance.')
+
+    # Get attributes from imported taxonomy module
+    elif ismodule(taxonomy):
+        tax = taxonomy.taxonomy
+        name = taxonomy.name
+        version = taxonomy.__version__
+        provenance = taxonomy.provenance
+
+    else:
+        raise TypeError('--taxonomy must be string or module.')
+
+    tax_obj = {
+        'name': name,
+        'provenance': provenance,
+        'version': version,
+        'hierarchy': tax,
+    }
 
     if group_ids is not None:
         if not hasattr(group_ids, "__iter__"):
             group_ids = (group_ids,)
-        tax["group_ids"] = list(group_ids)
+        tax_obj["group_ids"] = list(group_ids)
 
     response = fritz_api(
         "POST",
         f"{config['fritz']['protocol']}://{config['fritz']['host']}/api/taxonomy",
-        tax,
+        tax_obj,
     )
     print(response.json())
 


### PR DESCRIPTION
This PR modifies taxonomy.py to facilitate taxonomy uploads to Fritz. Users can now import a taxonomy module (e.g. [scope-phenomenology](https://github.com/bfhealy/scope-phenomenology) in python, pass in the module into taxonomy.py, and upload it. The original functionality requiring a path to a YAML file remains as another option, although users must now also specify a name, version and provenance.