### PR TITLE
Enable classifications from multiple taxonomies

### DIFF
--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -303,9 +303,14 @@ def save_newsource(
         df_photometry.dropna().drop_duplicates('expid').reset_index(drop=True)
     )
 
-    # hardcoded this because it is easier, but if Fritz ever changes
-    # this number will change
-    instrument_id = 1
+    # Get up-to-date ZTF instrument id
+    name = 'ZTF'
+    response_instruments = api('GET', 'api/instrument', token)
+    instrument_data = response_instruments.json().get('data')
+
+    for instrument in instrument_data:
+        if instrument['name'] == name:
+            instrument_id = instrument['id']
 
     photometry = {
         "obj_id": obj_id,

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -297,58 +297,41 @@ def save_newsource(
                 except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
                     print(f'Error - Retrying (attempt {attempt+1}).')
 
-    # start by checking for existing photometry
-    for attempt in range(MAX_ATTEMPTS):
-        try:
-            response = api("GET", f'/api/sources/{obj_id}/photometry', token)
-            data = response.json().get('data')
-            break
-        except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
-            print(f'Error - Retrying (attempt {attempt+1}).')
-
     # get photometry; drop flagged/nan data
     df_photometry = make_photometry(light_curves, drop_flagged=True)
     df_photometry = (
         df_photometry.dropna().drop_duplicates('expid').reset_index(drop=True)
     )
 
-    # if no photometry exists or there is a difference, post the lightcurves
-    if len(data) != len(df_photometry):
-        # if existing photometry, identify new data and ignore existing
-        if len(data) > 0:
-            df_phot_existing = pd.DataFrame(data)
-            indices_new = df_photometry['mjd'] > np.max(df_phot_existing['mjd'])
-            df_photometry = df_photometry[indices_new]
+    # hardcoded this because it is easier, but if Fritz ever changes
+    # this number will change
+    instrument_id = 1
 
-        # hardcoded this because it is easier, but if Fritz ever changes
-        # this number will change
-        instrument_id = 1
+    photometry = {
+        "obj_id": obj_id,
+        "instrument_id": instrument_id,
+        "mjd": df_photometry["mjd"].tolist(),
+        "mag": df_photometry["mag"].tolist(),
+        "magerr": df_photometry["magerr"].tolist(),
+        "limiting_mag": df_photometry["zp"].tolist(),
+        "magsys": df_photometry["magsys"].tolist(),
+        "filter": df_photometry["ztf_filter"].tolist(),
+        "ra": df_photometry["ra"].tolist(),
+        "dec": df_photometry["dec"].tolist(),
+    }
 
-        photometry = {
-            "obj_id": obj_id,
-            "instrument_id": instrument_id,
-            "mjd": df_photometry["mjd"].tolist(),
-            "mag": df_photometry["mag"].tolist(),
-            "magerr": df_photometry["magerr"].tolist(),
-            "limiting_mag": df_photometry["zp"].tolist(),
-            "magsys": df_photometry["magsys"].tolist(),
-            "filter": df_photometry["ztf_filter"].tolist(),
-            "ra": df_photometry["ra"].tolist(),
-            "dec": df_photometry["dec"].tolist(),
-        }
-
-        if (len(photometry.get("mag", ())) > 0) & (not dryrun):
-            print("Attempting to upload as %s" % obj_id)
-            for attempt in range(MAX_ATTEMPTS):
-                try:
-                    response = api("PUT", "/api/photometry", token, photometry)
-                    if response.json()["status"] == "error":
-                        print('Failed to post to Fritz')
-                        print(response.json())
-                        return None
-                    break
-                except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
-                    print(f'Error - Retrying (attempt {attempt+1}).')
+    if (len(photometry.get("mag", ())) > 0) & (not dryrun):
+        print("Uploading photmetry for %s" % obj_id)
+        for attempt in range(MAX_ATTEMPTS):
+            try:
+                response = api("PUT", "/api/photometry", token, photometry)
+                if response.json()["status"] == "error":
+                    print('Failed to post photometry to Fritz')
+                    print(response.json())
+                    return None
+                break
+            except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+                print(f'Error - Retrying (attempt {attempt+1}).')
 
     if period is not None:
         # upload the period if it is provided

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -311,6 +311,7 @@ def save_newsource(
     for instrument in instrument_data:
         if instrument['name'] == name:
             instrument_id = instrument['id']
+            break
 
     photometry = {
         "obj_id": obj_id,

--- a/tools/golden_dataset_mapper.json
+++ b/tools/golden_dataset_mapper.json
@@ -1,0 +1,276 @@
+{
+"variable":
+    {"fritz_label": "variable",
+      "taxonomy_id": 1012
+    },
+
+"periodic":
+    {"fritz_label": "periodic",
+      "taxonomy_id": 1012
+    },
+
+"pulsator":
+    {"fritz_label": "Pulsating",
+      "taxonomy_id": 1011
+    },
+
+"RR Lyrae":
+    {"fritz_label": "RR Lyrae",
+      "taxonomy_id": 1011
+    },
+
+"Cepheid":
+    {"fritz_label": "Cepheid",
+      "taxonomy_id": 1011
+    },
+
+"multi periodic":
+    {"fritz_label": "multi periodic",
+      "taxonomy_id": 1012
+    },
+
+"sinusoidal":
+    {"fritz_label": "sinusoidal",
+      "taxonomy_id": 1012
+    },
+
+"non-variable":
+    {"fritz_label": "non-variable",
+      "taxonomy_id:": 1012
+    },
+
+"bogus":
+    {"fritz_label": "bogus",
+      "taxonomy_id": 1012
+    },
+
+"bright star":
+    {"fritz_label": "bright star",
+      "taxonomy_id": 1012
+    },
+
+"long timescale":
+    {"fritz_label": "long timescale",
+      "taxonomy_id": 1012
+    },
+
+"irregular":
+    {"fritz_label": "irregular",
+      "taxonomy_id": 1012
+    },
+
+"blend":
+    {"fritz_label": "blend",
+      "taxonomy_id": 1012
+    },
+
+"galaxy":
+    {"fritz_label": "galaxy",
+      "taxonomy_id": 1012
+    },
+
+"eclipsing":
+    {"fritz_label": "eclipsing",
+      "taxonomy_id": 1012
+    },
+
+"EW":
+    {"fritz_label": "EW",
+      "taxonomy_id": 1012
+    },
+
+"flaring":
+    {"fritz_label": "flaring",
+      "taxonomy_id": 1012
+    },
+
+"ccd artifact":
+    {"fritz_label": "ccd artifact",
+      "taxonomy_id": 1012
+    },
+
+"binary star":
+    {"fritz_label": "Eclipsing",
+      "taxonomy_id": 1011
+    },
+
+"detached eclipsing MS-MS":
+    {"fritz_label": "detached MS-MS",
+      "taxonomy_id": 1011
+    },
+
+"W UMa":
+    {"fritz_label": "W Ursae Maj",
+      "taxonomy_id": 1011
+    },
+
+"RR Lyrae ab":
+    {"fritz_label": "RRab",
+      "taxonomy_id": 1011
+    },
+
+"RR Lyrae c":
+    {"fritz_label": "RRc",
+      "taxonomy_id": 1011
+    },
+
+"Delta Scu":
+    {"fritz_label": "Delta Scuti",
+      "taxonomy_id": 1011
+    },
+
+"RR Lyrae d":
+    {"fritz_label": "RRd",
+      "taxonomy_id": 1011
+    },
+
+"Cepheid type-II":
+    {"fritz_label": "Population II Cepheid",
+      "taxonomy_id": 1011
+    },
+
+"RS CVn":
+    {"fritz_label": "RS CVn",
+    "taxonomy_id": 1011
+    },
+
+"EB":
+    {"fritz_label": "EB",
+      "taxonomy_id": 1012
+    },
+
+"Beta Lyr":
+    {"fritz_label": "Beta Lyrae",
+      "taxonomy_id": 1011
+    },
+
+"sawtooth":
+    {"fritz_label": "sawtooth",
+      "taxonomy_id": 1012
+    },
+
+"RR Lyrae Blazhko":
+    {"fritz_label": "Blazhko",
+      "taxonomy_id": 1011
+    },
+
+"EA":
+    {"fritz_label": "EA",
+      "taxonomy_id": 1012
+    },
+
+"YSO":
+    {"fritz_label": "YSO",
+      "taxonomy_id": 1011
+    },
+
+"dipping":
+    {"fritz_label": "dipping",
+      "taxonomy_id": 1012
+    },
+
+"wrong period":
+    {"fritz_label": "wrong period",
+      "taxonomy_id": 1012
+    },
+
+"double period":
+    {"fritz_label": "double period",
+      "taxonomy_id": 1012
+    },
+
+"AGN":
+    {"fritz_label": "AGN",
+      "taxonomy_id": 1011
+    },
+
+"RV Tau":
+    {"fritz_label": "RV Tau",
+      "taxonomy_id": 1011
+    },
+
+"LPV":
+    {"fritz_label": "LPV",
+      "taxonomy_id": 1011
+    },
+
+"Mira":
+    {"fritz_label": "Mira",
+      "taxonomy_id": 1011
+    },
+
+"half period":
+    {"fritz_label": "half period",
+      "taxonomy_id": 1012
+    },
+
+"SRV":
+    {"fritz_label": "Semiregular",
+      "taxonomy_id": 1011
+    },
+
+"W Virginis":
+    {"fritz_label": "W Vir",
+      "taxonomy_id": 1011
+    },
+
+"compact binary":
+    {"fritz_label": "Compact Binary",
+      "taxonomy_id": 1011
+    },
+
+"eclipsing WD+dM (NN Ser)":
+    {"fritz_label": "NN Ser",
+      "taxonomy_id": 1011
+    },
+
+"nice":
+    {"fritz_label": "None",
+      "taxonomy_id": -1
+    },
+
+"niice":
+    {"fritz_label": "None",
+      "taxonomy_id": -1
+    },
+
+"F":
+    {"fritz_label": "Fundamental",
+      "taxonomy_id": 1011
+    },
+
+"O":
+    {"fritz_label": "Overtone",
+      "taxonomy_id": 1011
+    },
+
+"BL Her":
+    {"fritz_label": "BL Her",
+      "taxonomy_id": 1011
+    },
+
+"OSARG":
+    {"fritz_label": "OSARG",
+      "taxonomy_id": 1011
+    },
+
+"eclipsing sdB+dM (HW Vir)":
+    {"fritz_label": "HW Vir",
+      "taxonomy_id": 1011
+    },
+
+"elliptical":
+    {"fritz_label": "ellipsoidal",
+      "taxonomy_id": 1012
+    },
+
+"Redback pulsar":
+    {"fritz_label": "Redback Pulsar",
+      "taxonomy_id": 1011
+    },
+
+"CV":
+    {"fritz_label": "Cataclysmic",
+      "taxonomy_id": 1011
+    }
+}

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -75,6 +75,7 @@ def upload_classification(
     for index, row in sources.iterrows():
         probs = {}
         cls_list = []
+        tax_dict = {}
         existing_classes = []
 
         if read_classes:
@@ -84,10 +85,12 @@ def upload_classification(
             ]  # determine which dataset classifications are nonzero
 
             for val in nonzero_keys:
-                cls = tax_map[val]
+                cls = tax_map[val]['fritz_label']
+                tax_id = tax_map[val]['taxonomy_id']
                 if cls != 'None':  # if Fritz taxonomy value exists, add to class list
                     probs[cls] = row[val]
                     cls_list += [cls]
+                    tax_dict[cls] = tax_id
 
         else:
             # for manual i classifications, use last i columns for probability
@@ -177,12 +180,13 @@ def upload_classification(
         if classification is not None:
             for cls in cls_list:
                 if cls not in existing_classes:
+                    tax = tax_dict[cls]
                     prob = probs[cls]
                     # post all non-duplicate classifications
                     json = {
                         "obj_id": obj_id,
                         "classification": cls,
-                        "taxonomy_id": taxonomy_id,
+                        "taxonomy_id": tax,
                         "probability": prob,
                         "group_ids": group_ids,
                     }
@@ -250,9 +254,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "-taxonomy_id",
         type=int,
-        nargs='?',
-        default=9,
-        const=9,
         help="Fritz scope taxonomy id",
     )
     # parser.add_argument("-classification", type=str, help="name of object class")
@@ -283,7 +284,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "-skip_phot",
         type=bool,
+        nargs='?',
         default=False,
+        const=True,
         help="Skip photometry upload, only post groups and classifications.",
     )
 


### PR DESCRIPTION
This PR enables classifications spanning multiple taxonomies to be uploaded to Fritz. golden_dataset_mapper.json, which contains the mapping from dataset labels to Fritz classifications that gets passed into scope_upload_classification.py, is included as a new file in tools. This file also contains the taxonomy ids connected to each classification. Finally, since photometry uploaded to Fritz via the PUT request does not get duplicated, code comparing existing and new photometry in fritz.py has been removed to make uploads run faster.