### PR TITLE
Fix batch upload bugs and typos

### DIFF
--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -327,7 +327,7 @@ def save_newsource(
     }
 
     if (len(photometry.get("mag", ())) > 0) & (not dryrun):
-        print("Uploading photmetry for %s" % obj_id)
+        print("Uploading photometry for %s" % obj_id)
         for attempt in range(MAX_ATTEMPTS):
             try:
                 response = api("PUT", "/api/photometry", token, photometry)

--- a/tools/golden_dataset_mapper.json
+++ b/tools/golden_dataset_mapper.json
@@ -36,7 +36,7 @@
 
 "non-variable":
     {"fritz_label": "non-variable",
-      "taxonomy_id:": 1012
+      "taxonomy_id": 1012
     },
 
 "bogus":

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -50,10 +50,9 @@ def upload_classification(
     columns = sources.columns
 
     if start is not None:
-        if stop is not None:
-            sources = sources.loc[start:stop]
-        else:
-            sources = sources.loc[start:]
+        sources = sources.loc[start:]
+    if stop is not None:
+        sources = sources.loc[:stop]
 
     # for classification "read" mode, load taxonomy map
     read_classes = False

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -14,7 +14,7 @@ import pathlib
 # from time import sleep
 MAX_ATTEMPTS = 10
 RADIUS_ARCSEC = 2
-UPLOAD_BATCHSIZE = 100
+UPLOAD_BATCHSIZE = 10
 
 
 def upload_classification(
@@ -134,7 +134,7 @@ def upload_classification(
 
         # save_newsource can only be skipped if source exists
         if (len(existing_source) == 0) | (not skip_phot):
-            if len(existing_source) == 0:
+            if (len(existing_source) == 0) & (skip_phot):
                 warnings.warn('Cannot skip new source - saving.')
             obj_id = save_newsource(
                 gloria,
@@ -224,12 +224,13 @@ def upload_classification(
                         print(f'Error - Retrying (attempt {attempt+1}).')
 
         # batch upload classifications
-        if (index + 1) % UPLOAD_BATCHSIZE == 0:
+        if ((index - start) + 1) % UPLOAD_BATCHSIZE == 0:
             print('uploading classifications...')
             json_classes = {'classifications': dict_list}
             for attempt in range(MAX_ATTEMPTS):
                 try:
                     response = api("POST", "/api/classification", token, json_classes)
+                    dict_list = []
                     break
                 except (
                     InvalidJSONError,

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -239,6 +239,10 @@ def upload_classification(
                     OSError,
                 ):
                     print(f'Error - Retrying (attempt {attempt+1}).')
+                    if (attempt + 1) == MAX_ATTEMPTS:
+                        raise RuntimeError(
+                            'Reached max attempts without successful classification upload.'
+                        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes bugs relating to batch uploads of classifications:
- The list of classifications is now reset after each upload, preventing duplicate uploads
- The start/stop arguments can now be used independently
- UPLOAD_BATCHSIZE is limited to 10 by default instead of 100 (timeout)
- Batch uploads count up to UPLOAD_BATCHSIZE correctly regardless of start index
- An error is raised if MAX_ATTEMPTS is reached for batch uploads