### PR TITLE
Additional connection try/except

### DIFF
--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from requests.exceptions import InvalidJSONError
 from urllib3.exceptions import ProtocolError
+from json.decoder import JSONDecodeError
 
 MAX_ATTEMPTS = 10
 
@@ -294,7 +295,13 @@ def save_newsource(
                         print(f"Failed to save {obj_id} as a Source")
                         return None
                     break
-                except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+                except (
+                    InvalidJSONError,
+                    ConnectionError,
+                    ProtocolError,
+                    OSError,
+                    JSONDecodeError,
+                ):
                     print(f'Error - Retrying (attempt {attempt+1}).')
 
     # get photometry; drop flagged/nan data
@@ -310,7 +317,13 @@ def save_newsource(
         try:
             response_instruments = api('GET', 'api/instrument', token)
             break
-        except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+        except (
+            InvalidJSONError,
+            ConnectionError,
+            ProtocolError,
+            OSError,
+            JSONDecodeError,
+        ):
             print(f'Error - Retrying (attempt {attempt+1}).')
 
     instrument_data = response_instruments.json().get('data')
@@ -343,7 +356,13 @@ def save_newsource(
                     print(response.json())
                     return None
                 break
-            except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+            except (
+                InvalidJSONError,
+                ConnectionError,
+                ProtocolError,
+                OSError,
+                JSONDecodeError,
+            ):
                 print(f'Error - Retrying (attempt {attempt+1}).')
 
     if period is not None:
@@ -359,7 +378,13 @@ def save_newsource(
                     "POST", "api/sources/%s/annotations" % obj_id, token, data=data
                 )
                 break
-            except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+            except (
+                InvalidJSONError,
+                ConnectionError,
+                ProtocolError,
+                OSError,
+                JSONDecodeError,
+            ):
                 print(f'Error - Retrying (attempt {attempt+1}).')
 
     if return_id is True:

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -305,7 +305,14 @@ def save_newsource(
 
     # Get up-to-date ZTF instrument id
     name = 'ZTF'
-    response_instruments = api('GET', 'api/instrument', token)
+
+    for attempt in range(MAX_ATTEMPTS):
+        try:
+            response_instruments = api('GET', 'api/instrument', token)
+            break
+        except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+            print(f'Error - Retrying (attempt {attempt+1}).')
+
     instrument_data = response_instruments.json().get('data')
 
     for instrument in instrument_data:

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -8,6 +8,7 @@ import math
 import warnings
 from requests.exceptions import InvalidJSONError
 from urllib3.exceptions import ProtocolError
+from json.decoder import JSONDecodeError
 import yaml
 import pathlib
 
@@ -125,7 +126,13 @@ def upload_classification(
                 # sleep(0.9)
                 data = response.json().get("data")
                 break
-            except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+            except (
+                InvalidJSONError,
+                ConnectionError,
+                ProtocolError,
+                OSError,
+                JSONDecodeError,
+            ):
                 print(f'Error - Retrying (attempt {attempt+1}).')
 
         existing_source = []
@@ -172,7 +179,13 @@ def upload_classification(
                 try:
                     response = api("POST", "/api/source_groups", token, json)
                     break
-                except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+                except (
+                    InvalidJSONError,
+                    ConnectionError,
+                    ProtocolError,
+                    OSError,
+                    JSONDecodeError,
+                ):
                     print(f'Error - Retrying (attempt {attempt+1}).')
 
         # check for existing classifications
@@ -204,7 +217,13 @@ def upload_classification(
                     )
                     data_comments = response_comments.json().get("data")
                     break
-                except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+                except (
+                    InvalidJSONError,
+                    ConnectionError,
+                    ProtocolError,
+                    OSError,
+                    JSONDecodeError,
+                ):
                     print(f'Error - Retrying (attempt {attempt+1}).')
 
             # check for existing comments
@@ -223,7 +242,13 @@ def upload_classification(
                             "POST", f"/api/sources/{obj_id}/comments", token, json
                         )
                         break
-                    except (InvalidJSONError, ConnectionError, ProtocolError, OSError):
+                    except (
+                        InvalidJSONError,
+                        ConnectionError,
+                        ProtocolError,
+                        OSError,
+                        JSONDecodeError,
+                    ):
                         print(f'Error - Retrying (attempt {attempt+1}).')
 
         # batch upload classifications
@@ -240,6 +265,7 @@ def upload_classification(
                     ConnectionError,
                     ProtocolError,
                     OSError,
+                    JSONDecodeError,
                 ):
                     print(f'Error - Retrying (attempt {attempt+1}).')
                     if (attempt + 1) == MAX_ATTEMPTS:


### PR DESCRIPTION
This PR 'protects' an api call in fritz.py (added in #101) which previously lacked a try/except loop for connection errors (see #86). The PR also adds new connection-related error (JSONDecodeError) to check in fritz.py and scope_upload_classification.py.