### PR TITLE
Flip sign of magnitude difference

### DIFF
--- a/scope/utils.py
+++ b/scope/utils.py
@@ -243,7 +243,7 @@ def plot_gaia_hr(
     ax.errorbar(
         gaia_data["BP-RP"],
         gaia_data["M"],
-        gaia_data["M"] - gaia_data["Ml"],
+        gaia_data["Ml"] - gaia_data["M"],
         marker=".",
         color="#e68a00",
         alpha=0.75,


### PR DESCRIPTION
This PR flips the sign of a magnitude difference to avoid negative `yerr` values. 