### PR TITLE
Revise uploads and increase speed

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -107,6 +107,7 @@ inputs:
 8. Index to start uploading (zero-based)
 9. Index to stop uploading (inclusive)
 10. Skip photometry upload (existing sources only)
+11. Origin of ZTF data. If set, values in ztf_id CSV column will post as annotations.
 
 process:
 1. get object ids of all the data from Fritz using the ra, dec, and period
@@ -116,7 +117,7 @@ process:
 5. (post comment to each uploaded source)
 
 ```sh
-./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification variable flaring -token sample_token -taxonomy_map map.json -comment vetted -start 35 -stop 50 -skip_phot False
+./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification variable flaring -token sample_token -taxonomy_map map.json -comment vetted -start 35 -stop 50 -skip_phot False -ztf_origin ZTF_DR5
 ```
 
 ## Scope Upload Disagreements

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -96,7 +96,6 @@ def api(
 
     for attempt in range(max_attempts):
         try:
-            time.sleep(sleep_time)
             response = requests.request(**kwargs)
             break
         except (
@@ -107,6 +106,7 @@ def api(
             JSONDecodeError,
         ):
             print(f'Error - Retrying (attempt {attempt+1}).')
+            time.sleep(sleep_time)
             continue
 
     return response

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -6,13 +6,10 @@ from penquins import Kowalski
 from scope.fritz import save_newsource, api
 import math
 import warnings
-from requests.exceptions import InvalidJSONError
-from urllib3.exceptions import ProtocolError
-from json.decoder import JSONDecodeError
 import yaml
 import pathlib
+from tools import scope_manage_annotation
 
-# from time import sleep
 MAX_ATTEMPTS = 10
 RADIUS_ARCSEC = 2
 UPLOAD_BATCHSIZE = 10
@@ -29,6 +26,7 @@ def upload_classification(
     comment: str,
     start: int,
     stop: int,
+    origin: str,
     skip_phot: bool = False,
 ):
     """
@@ -43,6 +41,7 @@ def upload_classification(
     :param comment: single comment to post (str)
     :param start: index in CSV file to start upload (int)
     :param stop: index in CSV file to stop upload (inclusive) (int)
+    :origin: origin of uploaded data, posted to id annotation (str)
     :skip_phot: if True, only upload groups and classifications (no photometry) (bool)
     """
 
@@ -116,30 +115,24 @@ def upload_classification(
             warnings.warn('period column is missing - skipping period upload.')
 
         # get object id
-        for attempt in range(MAX_ATTEMPTS):
-            try:
-                response = api(
-                    "GET",
-                    f"/api/sources?&ra={ra}&dec={dec}&radius={RADIUS_ARCSEC/3600}",
-                    token,
-                )
-                # sleep(0.9)
-                data = response.json().get("data")
-                break
-            except (
-                InvalidJSONError,
-                ConnectionError,
-                ProtocolError,
-                OSError,
-                JSONDecodeError,
-            ):
-                print(f'Error - Retrying (attempt {attempt+1}).')
+        response = api(
+            "GET",
+            f"/api/sources?&ra={ra}&dec={dec}&radius={RADIUS_ARCSEC/3600}",
+            token,
+        )
+        data = response.get('data')
 
         existing_source = []
         obj_id = None
         if data["totalMatches"] > 0:
-            existing_source = data['sources'][0]
-            obj_id = existing_source["id"]
+            # get most recent source
+            for src in data['sources']:
+                src_id = src['id']
+                if src_id[:4] == 'ZTFJ':
+                    existing_source = src
+                    obj_id = src_id
+                    break
+
         print(f"object {index} id:", obj_id)
 
         # save_newsource can only be skipped if source exists
@@ -175,18 +168,7 @@ def upload_classification(
         if len(add_group_ids) > 0:
             # save to new group_ids
             json = {"objId": obj_id, "inviteGroupIds": add_group_ids}
-            for attempt in range(MAX_ATTEMPTS):
-                try:
-                    response = api("POST", "/api/source_groups", token, json)
-                    break
-                except (
-                    InvalidJSONError,
-                    ConnectionError,
-                    ProtocolError,
-                    OSError,
-                    JSONDecodeError,
-                ):
-                    print(f'Error - Retrying (attempt {attempt+1}).')
+            response = api("POST", "/api/source_groups", token, json)
 
         # check for existing classifications
         for entry in data_classes:
@@ -210,21 +192,8 @@ def upload_classification(
 
         if comment is not None:
             # get comment text
-            for attempt in range(MAX_ATTEMPTS):
-                try:
-                    response_comments = api(
-                        "GET", f"/api/sources/{obj_id}/comments", token
-                    )
-                    data_comments = response_comments.json().get("data")
-                    break
-                except (
-                    InvalidJSONError,
-                    ConnectionError,
-                    ProtocolError,
-                    OSError,
-                    JSONDecodeError,
-                ):
-                    print(f'Error - Retrying (attempt {attempt+1}).')
+            response_comments = api("GET", f"/api/sources/{obj_id}/comments", token)
+            data_comments = response_comments.json().get("data")
 
             # check for existing comments
             existing_comments = []
@@ -236,42 +205,22 @@ def upload_classification(
                 json = {
                     "text": comment,
                 }
-                for attempt in range(MAX_ATTEMPTS):
-                    try:
-                        response = api(
-                            "POST", f"/api/sources/{obj_id}/comments", token, json
-                        )
-                        break
-                    except (
-                        InvalidJSONError,
-                        ConnectionError,
-                        ProtocolError,
-                        OSError,
-                        JSONDecodeError,
-                    ):
-                        print(f'Error - Retrying (attempt {attempt+1}).')
+                response = api("POST", f"/api/sources/{obj_id}/comments", token, json)
+
+        # Post ZTF ID as annotation
+        if origin is not None:
+            ztfid = row['ztf_id']
+            scope_manage_annotation.manage_annotation(
+                'POST', obj_id, group_ids, token, origin, 'ztf_id', ztfid
+            )
 
         # batch upload classifications
-        if (((index - start) + 1) % UPLOAD_BATCHSIZE == 0) | (index == stop):
-            print('uploading classifications...')
-            json_classes = {'classifications': dict_list}
-            for attempt in range(MAX_ATTEMPTS):
-                try:
-                    response = api("POST", "/api/classification", token, json_classes)
-                    dict_list = []
-                    break
-                except (
-                    InvalidJSONError,
-                    ConnectionError,
-                    ProtocolError,
-                    OSError,
-                    JSONDecodeError,
-                ):
-                    print(f'Error - Retrying (attempt {attempt+1}).')
-                    if (attempt + 1) == MAX_ATTEMPTS:
-                        raise RuntimeError(
-                            'Reached max attempts without successful classification upload.'
-                        )
+        if len(dict_list) != 0:
+            if (((index - start) + 1) % UPLOAD_BATCHSIZE == 0) | (index == stop):
+                print('uploading classifications...')
+                json_classes = {'classifications': dict_list}
+                api("POST", "/api/classification", token, json_classes)
+                dict_list = []
 
 
 if __name__ == "__main__":
@@ -324,6 +273,8 @@ if __name__ == "__main__":
         help="Skip photometry upload, only post groups and classifications.",
     )
 
+    parser.add_argument("-origin", type=str, help="Origin of uploaded data")
+
     args = parser.parse_args()
 
     # upload classification objects
@@ -338,5 +289,6 @@ if __name__ == "__main__":
         args.comment,
         args.start,
         args.stop,
+        args.origin,
         args.skip_phot,
     )

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -27,7 +27,7 @@ def upload_classification(
     comment: str,
     start: int,
     stop: int,
-    origin: str,
+    ztf_origin: str,
     skip_phot: bool = False,
 ):
     """
@@ -42,7 +42,7 @@ def upload_classification(
     :param comment: single comment to post (str)
     :param start: index in CSV file to start upload (int)
     :param stop: index in CSV file to stop upload (inclusive) (int)
-    :origin: origin of uploaded data, posted to id annotation (str)
+    :ztf_origin: origin of uploaded ZTF data; if set, posts ztf_id to annotation (str)
     :skip_phot: if True, only upload groups and classifications (no photometry) (bool)
     """
 
@@ -222,10 +222,10 @@ def upload_classification(
                 response = api("POST", f"/api/sources/{obj_id}/comments", token, json)
 
         # Post ZTF ID as annotation
-        if origin is not None:
+        if ztf_origin is not None:
             ztfid = str(row['ztf_id'])
             scope_manage_annotation.manage_annotation(
-                'POST', obj_id, group_ids, token, origin, 'ztf_id', ztfid
+                'POST', obj_id, group_ids, token, ztf_origin, 'ztf_id', ztfid
             )
 
         # batch upload classifications
@@ -287,7 +287,7 @@ if __name__ == "__main__":
         help="Skip photometry upload, only post groups and classifications.",
     )
 
-    parser.add_argument("-origin", type=str, help="Origin of uploaded data")
+    parser.add_argument("-ztf_origin", type=str, help="Origin of uploaded ZTF data")
 
     args = parser.parse_args()
 
@@ -303,6 +303,6 @@ if __name__ == "__main__":
         args.comment,
         args.start,
         args.stop,
-        args.origin,
+        args.ztf_origin,
         args.skip_phot,
     )


### PR DESCRIPTION
This PR revises source uploads by:
- Removing unneeded try/except loops (thanks to #111)
- Adding an optional upload of each source's ZTF id as an annotation
- Selecting the most recently posted source whose id begins with 'ZTFJ' as the existing source (if applicable). Previously, if multiple nearby sources existed, the script would effectively select one at random.
- Updating the usage documentation

fritz.py also has a one-line change to api(): the call to sleep() now takes place after an exception is caught. This change speeds up api calls that do not produce an error.
