### PR TITLE
Fix loop bug in get_field_features

### DIFF
--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -107,6 +107,8 @@ def get_features(
         print(df)
         print("dmdt shape", dmdt.shape)
 
+    return df, dmdt
+
 
 # get features of all ids in a field
 def get_field_features(
@@ -134,14 +136,18 @@ def get_field_features(
     df_collection = []
     dmdt_collection = []
     while 1:
-        # skip = id * limit
         query = {
             "query_type": "find",
             "query": {
                 "catalog": features_catalog,
-                "filter": {"_id": {"$in": source_ids[id * limit : (id + 1) * limit]}},
+                "filter": {
+                    "_id": {
+                        "$in": source_ids[
+                            id * limit : np.min([(id + 1) * limit, len(source_ids) - 1])
+                        ]
+                    }
+                },
             },
-            # "kwargs": {"limit": limit, "skip": skip},
         }
         response = kowalski.query(query=query)
         source_data = response.get("data")
@@ -150,7 +156,6 @@ def get_field_features(
             print(response)
             raise ValueError(f"No data found for source ids {source_ids}")
 
-        # , index=np.arange(id*query_length,min((id+1)*query_length, len(source_data))))
         df_temp = pd.DataFrame.from_records(source_data)
         df_collection += [df_temp]
         try:
@@ -162,7 +167,8 @@ def get_field_features(
             print(df_temp)
         dmdt_collection += [dmdt_temp]
 
-        if ((id + 1) * limit) > len(source_ids):
+        if ((id + 1) * limit) >= len(source_ids):
+            print(f'{len(source_ids)} done')
             break
         id += 1
         if (id * limit) % 5000 == 0:
@@ -189,6 +195,8 @@ def get_field_features(
     if verbose:
         print(df)
         print("dmdt shape", dmdt.shape)
+
+    return df, dmdt
 
 
 def run(**kwargs):

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -140,13 +140,7 @@ def get_field_features(
             "query_type": "find",
             "query": {
                 "catalog": features_catalog,
-                "filter": {
-                    "_id": {
-                        "$in": source_ids[
-                            id * limit : np.min([(id + 1) * limit, len(source_ids) - 1])
-                        ]
-                    }
-                },
+                "filter": {"_id": {"$in": source_ids[id * limit : (id + 1) * limit]}},
             },
         }
         response = kowalski.query(query=query)

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -56,7 +56,7 @@ def get_features(
     id = 0
     df_collection = []
     dmdt_collection = []
-    while 1:
+    while True:
         skip = id * limit
         query = {
             "query_type": "find",
@@ -135,7 +135,7 @@ def get_field_features(
     id = 0
     df_collection = []
     dmdt_collection = []
-    while 1:
+    while True:
         query = {
             "query_type": "find",
             "query": {
@@ -187,8 +187,8 @@ def get_field_features(
         df.to_csv(outfile + ".csv", index=False)
 
     if verbose:
-        print(df)
-        print("dmdt shape", dmdt.shape)
+        print("Features dataframe: ", df)
+        print("dmdt shape: ", dmdt.shape)
 
     return df, dmdt
 


### PR DESCRIPTION
This PR fixes a bug that threw an error when using the `get_field_features` function within get_features.py. The criterion to break the loop has been modified so it doesn't fail when the length of the input list of source ids is an integer multiple of the per-query limit. Both get_features functions also now return their main outputs.