### PR TITLE
Enable source/feature merging

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -82,6 +82,9 @@ inputs:
 4. Flag to merge features from Kowalski with downloaded sources
 5. Name of features catalog to query
 6. Limit on number of sources to query at once
+7. Filename of classification mapper
+8. Name of directory to save downloaded files
+9. Name of file containing merged classifications and features
 
 process:
 1. if CSV file provided, query by object ids or ra, dec
@@ -94,7 +97,7 @@ process:
 output: data with new columns appended.
 
 ```sh
-./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000
+./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000 -mapper_name golden_dataset_mapper.json -output_dir fritzDownload -output_filename merged_classifications_features.csv
 ```
 
 ## Scope Upload Classification

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -89,6 +89,7 @@ process:
 3. get the classification/probabilities/periods of the objects in the dataset from Fritz
 4. append these values as new columns on the dataset, save to new file
 5. if merge_features, query Kowalski and merge sources with features, saving new CSV file
+6. To skip the source download part of the code, provide an input CSV file containing columns named 'obj_id', 'classification', 'probability', 'period_origin', 'period', 'ztf_id_origin', and 'ztf_id'.
 
 output: data with new columns appended.
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -77,20 +77,23 @@ done;
 ## Scope Download Classification
 inputs:
 1. CSV file containing obj_id and/or ra dec coordinates. Set to "parse" to download sources by group id.
-2. gloria object
-3. target group id(s) on Fritz for download (if CSV file not provided)
-4. Index or page number (if in "parse" mode) to begin downloading (optional)
+2. target group id(s) on Fritz for download (if CSV file not provided)
+3. Index or page number (if in "parse" mode) to begin downloading (optional)
+4. Flag to merge features from Kowalski with downloaded sources
+5. Name of features catalog to query
+6. Limit on number of sources to query at once
 
 process:
 1. if CSV file provided, query by object ids or ra, dec
 2. if CSV file not provided, bulk query based on group id(s)
 3. get the classification/probabilities/periods of the objects in the dataset from Fritz
 4. append these values as new columns on the dataset, save to new file
+5. if merge_features, query Kowalski and merge sources with features, saving new CSV file
 
 output: data with new columns appended.
 
 ```sh
-./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10
+./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000
 ```
 
 ## Scope Upload Classification

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -67,6 +67,7 @@ def get_features(
             + "field_"
             + str(field)
         )
+
     limit = kwargs.get("limit", 1000)
 
     id = 0
@@ -103,7 +104,7 @@ def get_features(
             print(f'{len(source_ids)} done')
             break
         id += 1
-        if (id * limit) % 5000 == 0:
+        if (id * limit) % limit == 0:
             print(id * limit, "done")
 
     df = pd.concat(df_collection, axis=0)

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -4,8 +4,8 @@ import pandas as pd
 from scope.fritz import api
 import warnings
 import numpy as np
-
-# from time import sleep
+from tools.get_features import get_features
+import os
 
 NUM_PER_PAGE = 500
 CHECKPOINT_NUM = 500
@@ -80,17 +80,150 @@ def organize_source_data(src: pd.DataFrame):
     return dct
 
 
-def download_classification(file: str, group_ids: list, start: int):
+def merge_sources_features(sources, features_catalog, features_limit=1000):
+
+    outpath = os.path.join(os.path.dirname(__file__), 'fritzDownload')
+    os.makedirs(outpath, exist_ok=True)
+
+    # Drop rows with no ZTF id
+    no_ztf_id = np.sum((sources.isna()['ztf_id']) | (sources['ztf_id'] == ''))
+    if no_ztf_id > 0:
+        print(f'Dropping {no_ztf_id} sources without a ZTF id.')
+        sources = sources[
+            ~((sources.isna()['ztf_id']) | (sources['ztf_id'] == ''))
+        ].reset_index(drop=True)
+
+    # Drop rows with duplicate ZTF ids (keep first instance)
+    dup_ztf_id = np.sum(sources.duplicated('ztf_id'))
+    if dup_ztf_id > 0:
+        print(f'Dropping {dup_ztf_id} sources with duplicate ZTF ids.')
+        sources = sources.drop_duplicates('ztf_id').reset_index(drop=True)
+
+    features_ztf_dr = features_catalog.split('_')[-1]
+    source_ids = sources['ztf_id'].values.astype(int).tolist()
+
+    # Open golden dataset mapper
+    mapper_dir = os.path.dirname(__file__)
+    mapper_path = os.path.join(mapper_dir, 'golden_dataset_mapper.json')
+    gold_map = pd.read_json(mapper_path)
+
+    # Drop columns with no equivalent in Fritz
+    none_cols = gold_map.loc['fritz_label'] == 'None'
+    gold_map = gold_map.drop(columns=none_cols.index[none_cols.values])
+    classes = gold_map.columns
+
+    # Manipulate golden_dataset_mapper to flip keys and values
+    gold_map = gold_map.transpose()
+    gold_map.index.rename('trainingset_label', inplace=True)
+    gold_map = gold_map.reset_index(drop=False).set_index('fritz_label')
+    gold_dict = gold_map.transpose().to_dict()
+
+    # Create empty dataframe for source classifications
+    expanded_sources = pd.DataFrame(
+        columns=np.concatenate([['obj_id'], classes, ['ztf_id']])
+    )
+    source_dict_list = []
+
+    for index, row in sources.iterrows():
+        gold_dict_specific = gold_dict.copy()
+
+        # Initiate dictonary to concatenate with existing dataframe
+        source_dict = {}
+        obj_id = row['obj_id']
+
+        # Assign Fritz object id
+        source_dict['obj_id'] = obj_id
+
+        classifications = []
+        completed_classifications = []
+
+        if not row.isna()['classification']:
+            classifications = row['classification'].split(';')
+            probabilities = row['probability'].split(';')
+
+        # Assign given probability values for each Fritz classification
+        for i in range(len(classifications)):
+            cls = classifications[i]
+            if cls not in completed_classifications:
+                trainingset_label = gold_dict_specific[cls]['trainingset_label']
+                gold_dict_specific.pop(cls)
+                completed_classifications += [cls]
+                source_dict[trainingset_label] = probabilities[i]
+
+        # Assign zero probability for remaining labels
+        for remaining_entry in gold_dict_specific:
+            if remaining_entry not in completed_classifications:
+                trainingset_label = gold_dict_specific[remaining_entry][
+                    'trainingset_label'
+                ]
+                source_dict[trainingset_label] = 0.0
+
+        # Assign ztf id
+        if not row.isna()['ztf_id']:
+            ztf_id_origin_dr = row['ztf_id_origin'].split('_')[-1]
+
+        # Check if Fritz ZTF DR number is the same as features catalog
+        ztf_id = row['ztf_id']
+        if ztf_id_origin_dr == features_ztf_dr:
+            source_dict['ztf_id'] = int(ztf_id)
+        else:
+            raise ValueError(
+                'ZTF data release numbers do not match between Fritz and features catalog.'
+            )
+
+        source_dict_list += [source_dict]
+
+    # Create dataframe
+    expanded_sources = pd.concat([expanded_sources, pd.DataFrame(source_dict_list)])
+
+    # Query Kowalski
+    print('Getting features...')
+    df, dmdt = get_features(
+        source_ids=source_ids,
+        features_catalog=features_catalog,
+        limit=features_limit,
+        write_results=False,
+    )
+    df['ztf_id'] = df['_id']
+    df = df.drop('_id', axis=1)
+
+    # Merge on ZTF id
+    merged_set = pd.merge(expanded_sources, df, on='ztf_id')
+
+    # Make ztf_id last column in dataframe
+    ztf_id_col = merged_set.pop('ztf_id')
+    merged_set['ztf_id'] = ztf_id_col
+
+    filepath = os.path.join(outpath, 'merged_classifications_features.csv')
+    merged_set.to_csv(filepath, index=False)
+    return merged_set
+
+
+def download_classification(
+    file: str,
+    group_ids: list,
+    start: int,
+    merge_features: bool,
+    features_catalog: str,
+    features_limit: int,
+):
     """
     Download labels from Fritz
     :param file: CSV file containing obj_id column or "parse" to query by group ids (str)
     :param group_ids: target group ids on Fritz for download (list)
-    :param start: page number to start downloading data from
+    :param start: page number to start downloading data from (int)
+    :param merge_features: if True,  query Kowalski for features to merge (bool)
+    :param features_catalog: catalog name to query for features (str)
+    :param features_limit: maximum number of sources to query for features per loop (int)
     """
 
     dict_list = []
 
+    outpath = os.path.join(os.path.dirname(__file__), 'fritzDownload')
+    os.makedirs(outpath, exist_ok=True)
+
     filename = file.removesuffix('.csv') + '_fritzDownload' + '.csv'  # rename file
+    filepath = os.path.join(outpath, filename)
 
     if file in ["parse", 'Parse', 'PARSE']:
         if group_ids is None:
@@ -111,6 +244,7 @@ def download_classification(file: str, group_ids: list, start: int):
             filename = (
                 filename.removesuffix('.csv') + f'_continued_page_{start}' + '.csv'
             )
+            filepath = os.path.join(outpath, filename)
             print('Downloading sources...')
         else:
             start = 1
@@ -135,10 +269,16 @@ def download_classification(file: str, group_ids: list, start: int):
 
             # create dataframe from query results
             sources = pd.json_normalize(dict_list)
-            sources.to_csv(filename, index=False)
+            sources.to_csv(filepath, index=False)
             print(f'Saved page {pageNum}.')
 
-        return sources
+        if not merge_features:
+            return sources
+        else:
+            merged_sources = merge_sources_features(
+                sources, features_catalog, features_limit
+            )
+            return merged_sources
 
     else:
         # read in CSV file
@@ -149,94 +289,116 @@ def download_classification(file: str, group_ids: list, start: int):
             filename = (
                 filename.removesuffix('.csv') + f'_continued_index_{start}' + '.csv'
             )
+            filepath = os.path.join(outpath, filename)
 
         columns = sources.columns
 
-        # create new empty columns
-        sources["classification"] = None
-        sources["probability"] = None
-        sources["period_origin"] = None
-        sources["period"] = None
-        sources["ztf_id_origin"] = None
-        sources["ztf_id"] = None
-        # add obj_id column if not passed in
-        if 'obj_id' not in columns:
-            sources["obj_id"] = None
-            search_by_obj_id = False
-        else:
-            search_by_obj_id = True
+        missing_col_count = 0
+        for colname in [
+            'classification',
+            'probability',
+            'period_origin',
+            'period',
+            'ztf_id_origin',
+            'ztf_id',
+        ]:
+            if colname not in columns:
+                missing_col_count += 1
+        if missing_col_count > 0:
+            # create new empty columns
+            sources["classification"] = None
+            sources["probability"] = None
+            sources["period_origin"] = None
+            sources["period"] = None
+            sources["ztf_id_origin"] = None
+            sources["ztf_id"] = None
+            # add obj_id column if not passed in
+            if 'obj_id' not in columns:
+                sources["obj_id"] = None
+                search_by_obj_id = False
+            else:
+                search_by_obj_id = True
 
-        for index, row in sources.iterrows():
-            # query objects, starting with obj_id
-            data = []
-            if search_by_obj_id:
-                obj_id = row.obj_id
-                response = api("GET", '/api/sources/%s' % obj_id)
-                # sleep(0.9)
-                data = response.json().get("data")
-                if len(data) == 0:
-                    warnings.warn('No results from obj_id search - querying by ra/dec.')
-                else:
-                    src = data
-
-            # continue with coordinate search if obj_id unsuccsessful
-            if len(data) == 0:
-                if ('ra' in columns) & ('dec' in columns):
-                    # query by ra/dec to get object id
-                    ra, dec = row.ra, row.dec
-                    response = api(
-                        "GET", f"/api/sources?&ra={ra}&dec={dec}&radius={2/3600}"
-                    )
+            for index, row in sources.iterrows():
+                # query objects, starting with obj_id
+                data = []
+                if search_by_obj_id:
+                    obj_id = row.obj_id
+                    response = api("GET", '/api/sources/%s' % obj_id)
                     # sleep(0.9)
                     data = response.json().get("data")
-                    obj_id = None
-                    if data["totalMatches"] > 0:
-                        src = data["sources"][0]
-                        obj_id = src["id"]
-                        sources.at[index, 'obj_id'] = obj_id
+                    if len(data) == 0:
+                        warnings.warn(
+                            'No results from obj_id search - querying by ra/dec.'
+                        )
+                    else:
+                        src = data
+
+                # continue with coordinate search if obj_id unsuccsessful
+                if len(data) == 0:
+                    if ('ra' in columns) & ('dec' in columns):
+                        # query by ra/dec to get object id
+                        ra, dec = row.ra, row.dec
+                        response = api(
+                            "GET",
+                            f"/api/sources?&ra={ra}&dec={dec}&radius={2/3600}",
+                        )
+                        # sleep(0.9)
+                        data = response.json().get("data")
+                        obj_id = None
+                        if data["totalMatches"] > 0:
+                            src = data["sources"][0]
+                            obj_id = src["id"]
+                            sources.at[index, 'obj_id'] = obj_id
+                    else:
+                        raise KeyError(
+                            'Attemped to search by coordinates, but unable to find ra and dec columns.'
+                        )
+
+                print(f"object {index} id:", obj_id)
+
+                # if successful search, get and save labels/probabilities/period annotations to sources dataframe
+                if obj_id is not None:
+                    (
+                        id,
+                        ra,
+                        dec,
+                        cls_list,
+                        prb_list,
+                        origin_list,
+                        period_list,
+                        id_origin_list,
+                        id_list,
+                    ) = organize_source_data(src)
+
+                    # store to new columns
+                    sources.at[index, 'ra'] = ra
+                    sources.at[index, 'dec'] = dec
+                    sources.at[index, 'classification'] = cls_list
+                    sources.at[index, 'probability'] = prb_list
+                    sources.at[index, 'period_origin'] = origin_list
+                    sources.at[index, 'period'] = period_list
+                    sources.at[index, 'ztf_id_origin'] = origin_list
+                    sources.at[index, 'ztf_id'] = period_list
+
+                    # occasional checkpoint at specified number of sources
+                    if (index + 1) % CHECKPOINT_NUM == 0:
+                        sources.to_csv(filepath, index=False)
+                        print(f'Saved checkpoint at index {index}.')
+
                 else:
-                    raise KeyError(
-                        'Attemped to search by coordinates, but unable to find ra and dec columns.'
-                    )
+                    warnings.warn(f'Unable to find source {index} on Fritz.')
 
-            print(f"object {index} id:", obj_id)
+                # final save
+                sources.to_csv(filepath, index=False)
 
-            # if successful search, get and save labels/probabilities/period annotations to sources dataframe
-            if obj_id is not None:
-                (
-                    id,
-                    ra,
-                    dec,
-                    cls_list,
-                    prb_list,
-                    origin_list,
-                    period_list,
-                    id_origin_list,
-                    id_list,
-                ) = organize_source_data(src)
-
-                # store to new columns
-                sources.at[index, 'ra'] = ra
-                sources.at[index, 'dec'] = dec
-                sources.at[index, 'classification'] = cls_list
-                sources.at[index, 'probability'] = prb_list
-                sources.at[index, 'period_origin'] = origin_list
-                sources.at[index, 'period'] = period_list
-                sources.at[index, 'ztf_id_origin'] = origin_list
-                sources.at[index, 'ztf_id'] = period_list
-
-                # occasional checkpoint at specified number of sources
-                if (index + 1) % CHECKPOINT_NUM == 0:
-                    sources.to_csv(filename, index=False)
-                    print(f'Saved checkpoint at index {index}.')
-
-            else:
-                warnings.warn(f'Unable to find source {index} on Fritz.')
-
-            # final save
-            sources.to_csv(filename, index=False)
-
-        return sources
+        if not merge_features:
+            return sources
+        else:
+            merged_sources = merge_sources_features(
+                sources, features_catalog, features_limit
+            )
+            return merged_sources
 
 
 if __name__ == "__main__":
@@ -247,7 +409,36 @@ if __name__ == "__main__":
     parser.add_argument(
         "-start", type=int, default=0, help="start page/index for continued download"
     )
+    parser.add_argument(
+        "-merge_features",
+        type=bool,
+        nargs='?',
+        const=True,
+        default=False,
+        help="merge downloaded results with features from Kowalski",
+    )
+    parser.add_argument(
+        "-features_catalog",
+        type=str,
+        default='ZTF_source_features_DR5',
+        help="catalog of features on Kowalksi",
+    )
+
+    parser.add_argument(
+        "-features_limit",
+        type=int,
+        default=1000,
+        help="Maximum number of sources queried for features per loop",
+    )
+
     args = parser.parse_args()
 
     # download object classifications in the file
-    download_classification(args.file, args.group_ids, args.start)
+    download_classification(
+        args.file,
+        args.group_ids,
+        args.start,
+        args.merge_features,
+        args.features_catalog,
+        args.features_limit,
+    )

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -80,9 +80,16 @@ def organize_source_data(src: pd.DataFrame):
     return dct
 
 
-def merge_sources_features(sources, features_catalog, features_limit=1000):
+def merge_sources_features(
+    sources,
+    features_catalog,
+    features_limit=1000,
+    mapper_name='golden_dataset_mapper.json',
+    output_dir='fritzDownload',
+    output_filename='merged_classifications_features.csv',
+):
 
-    outpath = os.path.join(os.path.dirname(__file__), 'fritzDownload')
+    outpath = os.path.join(os.path.dirname(__file__), output_dir)
     os.makedirs(outpath, exist_ok=True)
 
     # Drop rows with no ZTF id
@@ -104,7 +111,7 @@ def merge_sources_features(sources, features_catalog, features_limit=1000):
 
     # Open golden dataset mapper
     mapper_dir = os.path.dirname(__file__)
-    mapper_path = os.path.join(mapper_dir, 'golden_dataset_mapper.json')
+    mapper_path = os.path.join(mapper_dir, mapper_name)
     gold_map = pd.read_json(mapper_path)
 
     # Drop columns with no equivalent in Fritz
@@ -194,7 +201,7 @@ def merge_sources_features(sources, features_catalog, features_limit=1000):
     ztf_id_col = merged_set.pop('ztf_id')
     merged_set['ztf_id'] = ztf_id_col
 
-    filepath = os.path.join(outpath, 'merged_classifications_features.csv')
+    filepath = os.path.join(outpath, output_filename)
     merged_set.to_csv(filepath, index=False)
     return merged_set
 
@@ -206,6 +213,9 @@ def download_classification(
     merge_features: bool,
     features_catalog: str,
     features_limit: int,
+    mapper_name: str = 'golden_dataset_mapper.json',
+    output_dir: str = 'fritzDownload',
+    output_filename: str = 'merged_classifications_features.csv',
 ):
     """
     Download labels from Fritz
@@ -219,7 +229,7 @@ def download_classification(
 
     dict_list = []
 
-    outpath = os.path.join(os.path.dirname(__file__), 'fritzDownload')
+    outpath = os.path.join(os.path.dirname(__file__), output_dir)
     os.makedirs(outpath, exist_ok=True)
 
     filename = (
@@ -279,7 +289,12 @@ def download_classification(
             return sources
         else:
             merged_sources = merge_sources_features(
-                sources, features_catalog, features_limit
+                sources,
+                features_catalog,
+                features_limit,
+                mapper_name,
+                output_dir,
+                output_filename,
             )
             return merged_sources
 
@@ -387,7 +402,12 @@ def download_classification(
             return sources
         else:
             merged_sources = merge_sources_features(
-                sources, features_catalog, features_limit
+                sources,
+                features_catalog,
+                features_limit,
+                mapper_name,
+                output_dir,
+                output_filename,
             )
             return merged_sources
 
@@ -422,6 +442,27 @@ if __name__ == "__main__":
         help="Maximum number of sources queried for features per loop",
     )
 
+    parser.add_argument(
+        "-mapper_name",
+        type=str,
+        default='golden_dataset_mapper.json',
+        help="Filename of classification mapper",
+    )
+
+    parser.add_argument(
+        "-output_dir",
+        type=str,
+        default='fritzDownload',
+        help="Name of directory to save downloaded files",
+    )
+
+    parser.add_argument(
+        "-output_filename",
+        type=str,
+        default='merged_classifications_features.csv',
+        help="Name of file containing merged classifications and features",
+    )
+
     args = parser.parse_args()
 
     # download object classifications in the file
@@ -432,4 +473,7 @@ if __name__ == "__main__":
         args.merge_features,
         args.features_catalog,
         args.features_limit,
+        args.mapper_name,
+        args.output_dir,
+        args.output_filename,
     )


### PR DESCRIPTION
This PR incorporates the get_features.py code into scope_download_classification.py to query and download features from Kowalski before merging them with a source list from Fritz, either downloaded or provided as input (closes #58). The merge is done by matching ZTF id numbers after checking that both tables come from the same data release. 

All files produced by scope_download_classification are now saved in a directory called 'fritzDownload' within scope/tools. Previously they were saved in the tools directory.

My tests of the the code produce the same form of file as the initial golden dataset, with minor differences in columns. The newly produced dataset has an additional column called 'coordinates' from the features database, and it is missing the 'nice' and 'niice' classification columns that we have not uploaded to Fritz. The 'zvm_id' column is replaced with 'obj_id' containing the coordinate-based names of each object from Fritz.