### PR TITLE
Handle unrecognized classifications when merging features

### DIFF
--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -152,10 +152,14 @@ def merge_sources_features(
         for i in range(len(classifications)):
             cls = classifications[i]
             if cls not in completed_classifications:
-                trainingset_label = gold_dict_specific[cls]['trainingset_label']
-                gold_dict_specific.pop(cls)
+                try:
+                    trainingset_label = gold_dict_specific[cls]['trainingset_label']
+                    gold_dict_specific.pop(cls)
+                    source_dict[trainingset_label] = probabilities[i]
+                except KeyError:
+                    print(f'Key {cls} not in dataset mapper.')
+                    continue
                 completed_classifications += [cls]
-                source_dict[trainingset_label] = probabilities[i]
 
         # Assign zero probability for remaining labels
         for remaining_entry in gold_dict_specific:


### PR DESCRIPTION
This PR modifies the feature-merging part of scope_download_classification.py to handle classifications that are not in the input dataset label mapper. This issue arises, for example, when a source already existed on Fritz with classifications from a separate taxonomy prior to the user's upload of that source. The new code skips over classifications that are missing from the mapper, which the user can modify if the additional classifications are of interest.