### PR TITLE
Consolidate get_quad_ids functions

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,14 +1,30 @@
 # Usage
 
-## Download ids for a ZTF quad
+## Download ids for ZTF fields/CCDs/quadrants
 
-```python
-get_field_ids.py
-ZTF_sources_20210401 -field 301 -ccd 2 -quad 3 -minobs 5 -skip 0 -limit 20 -token sample_token
+- Create CSV file for single CCD/quad pair in a field:
+
+```sh
+./get_quad_ids.py --catalog ZTF_source_features_DR5 --field 301 --ccd 2 --quad 3 --minobs 20 --skip 0 --limit 10000
 ```
 
-It can then be put in a loop to, say, get 100 ids at a time from a quad,
-and/or loop over quads and CCDs to get all ids for a field.
+- Create multiple HDF5 files for some CCD/quad pairs in a field:
+
+```sh
+./get_quad_ids.py --catalog ZTF_source_features_DR5 --field 301 --multi-quads --ccd-range 1 8 --quad-range 2 4 --minobs 20 --limit 10000
+```
+
+- Create multiple HDF5 files for all CCD/quad pairs in a field:
+
+```sh
+./get_quad_ids.py --catalog ZTF_source_features_DR5 --field 301 --multi-quads --minobs 20 --limit 10000
+```
+
+- Create single HDF5 file for all sources in a field:
+
+```sh
+./get_quad_ids.py --catalog ZTF_source_features_DR5 --field 301 --whole-field
+```
 
 ## Training deep learning models
 
@@ -67,8 +83,8 @@ done;
 * Requires `models/` folder in the root directory containing the pre-trained models for `dnn` and `xgboost`.
 * The commands for inference of the field `<field_number>` (in order)
   ```
-  python tools/get_quad_ids.py --field=<field_number>
-  python tools/get_features.py --field=<field_number>
+  ./tools/get_quad_ids.py --field=<field_number> --whole-field
+  ./tools/get_features.py --field=<field_number>
   ./get_all_preds.sh <field_number>
   ```
 * Creates a single `.csv` file containing all ids of the field in the rows and inference scores for different classes across the columns.
@@ -125,24 +141,6 @@ process:
 ./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification variable flaring -taxonomy_map map.json -comment vetted -start 35 -stop 50 -skip_phot False -ztf_origin ZTF_DR5
 ```
 
-## Scope Upload Disagreements
-inputs:
-1. dataset
-2. group id on Fritz
-3. gloria object
-
-process:
-1. read in the csv dataset to pandas dataframe
-2. get high scoring objects on DNN or on XGBoost from Fritz
-3. get objects that have high confidence on DNN but low confidence on XGBoost and vice versa
-4. get different statistics of those disagreeing objects and combine to a dataframe
-5. filter those disagreeing objects that are contained in the training set and remove them
-6. upload the remaining disagreeing objects to target group on Fritz
-
-```sh
-./scope_upload_disagreements.py -file dataset.d15.csv -id 360 -token sample_token
-```
-
 ## Scope Manage Annotation
 inputs:
 1. action (one of "post", "update", or "delete")
@@ -159,4 +157,22 @@ process:
 
 ```sh
 ./scope_manage_annotation.py -action post -source sample.csv -group_ids 200 300 400 -origin revisedperiod -key period
+```
+
+## Scope Upload Disagreements
+inputs:
+1. dataset
+2. group id on Fritz
+3. gloria object
+
+process:
+1. read in the csv dataset to pandas dataframe
+2. get high scoring objects on DNN or on XGBoost from Fritz
+3. get objects that have high confidence on DNN but low confidence on XGBoost and vice versa
+4. get different statistics of those disagreeing objects and combine to a dataframe
+5. filter those disagreeing objects that are contained in the training set and remove them
+6. upload the remaining disagreeing objects to target group on Fritz
+
+```sh
+./scope_upload_disagreements.py -file dataset.d15.csv -id 360 -token sample_token
 ```

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -18,7 +18,7 @@ with open(config_path) as config_yaml:
 gloria = Kowalski(**config['kowalski'], verbose=False)
 
 
-def get_ids(
+def get_ids_loop(
     func,
     catalog,
     field=301,
@@ -59,7 +59,7 @@ def get_ids(
         Single or separate hdf5 files (field_<field_number>.h5 or data_<ccd_number>_quad_<quad_number>.h5)
         for all the quads in the specified range.
 
-        USAGE: get_ids(get_field_ids, 'ZTF_sources_20210401',field=301,ccd_range=[1,2],quad_range=[2,4],\
+        USAGE: get_ids_loop(get_field_ids, 'ZTF_sources_20210401',field=301,ccd_range=[1,2],quad_range=[2,4],\
             minobs=5,limit=2000, whole_field=False)
         '''
     if output_dir is None:
@@ -306,7 +306,7 @@ if __name__ == "__main__":
             print('Saving single file for entire field across ccd/quadrant range.')
         else:
             print('Saving multiple files for each ccd/quadrant pair.')
-        get_ids(
+        get_ids_loop(
             get_field_ids,
             catalog=args.catalog,
             field=args.field,

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -1,164 +1,71 @@
+#!/usr/bin/env python
 import argparse
 from penquins import Kowalski
 import pandas as pd
 import numpy as np
 import json
-import sys
 import os
 import h5py
+import pathlib
+import yaml
 
 BASE_DIR = os.path.dirname(__file__)
+# Set up gloria connection
+# Use Kowalski_Instances class here once approved
+config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
+with open(config_path) as config_yaml:
+    config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+gloria = Kowalski(**config['kowalski'], verbose=False)
 
 
-def get_all_ids(
+def get_ids(
     func,
     catalog,
     field=301,
-    ccd_range=16,
-    quad_range=4,
+    ccd_range=[1, 16],
+    quad_range=[1, 4],
     minobs=20,
-    limit=0,
+    limit=10000,
     verbose=2,
-    output_dir=os.path.join(os.path.dirname(__file__), "output/"),
+    output_dir=None,
+    whole_field=False,
 ):
     '''
-    Function wrapper for getting all field ids in a particular ccd and quad range
+        Function wrapper for getting ids in a particular ccd and quad range
 
-    Parameters
-    ==========
-    func : function
-        Function for getting ids for a specific quad of a CCD for a particular ZTF field.
-    catalog : str
-        Catalog containing ids, CCD, quad, and light curves
-    field : int
-        ZTF field number
-    ccd_range : int
-        Range of CCD numbers starting from 1 to get the ids. Takes values from [1,16]
-    quad_range : int
-        Range of CCD quad numbers starting from 1. Takes values from [1,4]
-    minobs : int
-        Minimum points in the light curve for the object to be selected
-    limit : int
-        How many of the selected rows to return. Default is 10000
-    output_dir : str
-        Relative directory path to save output files to
-    Returns
-    =======
-    Stores separate hdf5 files for each quad in the specified range in a directory
+        Parameters
+        ----------
+        func : function
+            Function for getting ids for a specific quad of a CCD for a particular ZTF field.
+        catalog : str
+            Catalog containing ids, CCD, quad, and light curves
+        field : int
+            ZTF field number
+        ccd_range : int
+            Range of CCD numbers starting from 1 to get the ids. Takes values from [1,16]
+        quad_range : int
+            Range of CCD quad numbers starting from 1. Takes values from [1,4]
+        minobs : int
+            Minimum points in the light curve for the object to be selected
+        limit : int
+            How many of the selected rows to return. Default is 10000
+        output_dir : str
+            Relative directory path to save output files to
+        whole_field: bool
+            If True, save one file containing all field ids. Otherwise, save files for each ccd/quad pair
 
-    USAGE: get_all_ids(get_field_ids, 'ZTF_sources_20210401',field=301,ccd_range=2,quad_range=4,\
-        minobs=5,limit=2000)
-    '''
-    os.makedirs(output_dir, exist_ok=True)
+        Returns
+        -------
+        Single or separate hdf5 files (field_<field_number>.h5 or data_<ccd_number>_quad_<quad_number>.h5)
+        for all the quads in the specified range.
 
-    dct = {}
-    if verbose > 0:
-        dct["catalog"] = catalog
-        dct["minobs"] = minobs
-        dct["field"] = field
-        dct["ccd_range"] = ccd_range
-        dct["quad_range"] = quad_range
-        dct["ccd"] = {}
-        count = 0
-    for ccd in range(1, ccd_range + 1):
-        dct["ccd"][ccd] = {}
-        dct["ccd"][ccd]["quad"] = {}
-        for quad in range(1, quad_range + 1):
-
-            if verbose > 1:
-                hf = h5py.File(
-                    output_dir
-                    + 'data_ccd_'
-                    + str(ccd).zfill(2)
-                    + '_quad_'
-                    + str(quad)
-                    + '.h5',
-                    'w',
-                )
-            i = 0
-            ser = pd.Series(np.array([]))
-            while 1:
-                data = func(
-                    catalog,
-                    field=field,
-                    ccd=ccd,
-                    quad=quad,
-                    minobs=minobs,
-                    skip=(i * limit),
-                    limit=limit,
-                )
-                # concat data to series containing all data
-                if verbose > 1:
-                    ser = pd.concat([ser, pd.Series(data)], axis=0)
-                if len(data) < limit:
-                    if verbose > 0:
-                        length = len(data) + (i * limit)
-                        count += length
-                        dct["ccd"][ccd]["quad"][quad] = length
-                    hf.create_dataset(
-                        "dataset_ccd_"
-                        + str(ccd)
-                        + "_quad_"
-                        + str(quad)
-                        + "_field_"
-                        + str(field),
-                        data=ser,
-                    )
-                    hf.close()
-                    break
-                i += 1
-    dct["total"] = count
-    # Write metadata in this file
-    f = output_dir + "meta.json"
-    os.makedirs(os.path.dirname(f), exist_ok=True)
-    with open(f, "w") as outfile:
-        try:
-            json.dump(dct, outfile)  # dump dictionary to a json file
-        except Exception as e:
-            print("error dumping to json, message: ", e)
-
-
-# get all field ids in one file
-def get_all_field_ids(
-    func,
-    catalog,
-    field=301,
-    ccd_range=16,
-    quad_range=4,
-    minobs=20,
-    limit=0,
-    verbose=2,
-    output_dir=os.path.join(os.path.dirname(__file__), "output/"),
-):
-    '''
-    Function wrapper for getting all field ids in a particular ccd and quad range
-    Parameters
-    ----------
-    func : function
-        Function for getting ids for a specific quad of a CCD for a particular ZTF field.
-    catalog : str
-        Catalog containing ids, CCD, quad, and light curves
-    field : int
-        ZTF field number
-    ccd_range : int
-        Range of CCD numbers starting from 1 to get the ids. Takes values from [1,16]
-    quad_range : int
-        Range of CCD quad numbers starting from 1. Takes values from [1,4]
-    minobs : int
-        Minimum points in the light curve for the object to be selected
-    limit : int
-        How many of the selected rows to return. Default is 10000
-    output_dir : str
-        Relative directory path to save output files to
-
-    Returns
-    -------
-    Single hdf5 file (field_<field_number>.h5) for all the quads in the specified range.
-
-    USAGE: get_all_ids(get_field_ids, 'ZTF_sources_20210401',field=301,ccd_range=2,quad_range=4,\
-        minobs=5,limit=2000)
-    '''
-    os.makedirs(output_dir, exist_ok=True)
+        USAGE: get_ids(get_field_ids, 'ZTF_sources_20210401',field=301,ccd_range=[1,2],quad_range=[2,4],\
+            minobs=5,limit=2000, whole_field=False)
+        '''
+    if output_dir is None:
+        output_dir = os.path.join(
+            os.path.dirname(__file__), "../ids/field_" + str(field) + "/"
+        )
 
     dct = {}
     if verbose > 0:
@@ -171,13 +78,13 @@ def get_all_field_ids(
         count = 0
 
     ser = pd.Series(np.array([]))
-    for ccd in range(1, ccd_range + 1):
+    for ccd in range(ccd_range[0], ccd_range[1] + 1):
         dct["ccd"][ccd] = {}
         dct["ccd"][ccd]["quad"] = {}
-        for quad in range(1, quad_range + 1):
-            # dct["ccd"][ccd]["quad"][quad] = {}
+        for quad in range(quad_range[0], quad_range[1] + 1):
+
             i = 0
-            while 1:
+            while True:
                 data = func(
                     catalog,
                     field=field,
@@ -195,9 +102,30 @@ def get_all_field_ids(
                         length = len(data) + (i * limit)
                         count += length
                         dct["ccd"][ccd]["quad"][quad] = length
+                    if not whole_field:
+                        if verbose > 1:
+                            hf = h5py.File(
+                                output_dir
+                                + 'data_ccd_'
+                                + str(ccd).zfill(2)
+                                + '_quad_'
+                                + str(quad)
+                                + '.h5',
+                                'w',
+                            )
+                        hf.create_dataset(
+                            "dataset_ccd_"
+                            + str(ccd)
+                            + "_quad_"
+                            + str(quad)
+                            + "_field_"
+                            + str(field),
+                            data=ser,
+                        )
+                        hf.close()
                     break
                 i += 1
-    if verbose > 1:
+    if (verbose > 1) & (whole_field):
         hf = h5py.File(
             output_dir + "field_" + str(field) + '.h5',
             'w',
@@ -214,6 +142,8 @@ def get_all_field_ids(
             json.dump(dct, outfile)  # dump dictionary to a json file
         except Exception as e:
             print("error dumping to json, message: ", e)
+
+    return ser
 
 
 def get_field_ids(catalog, field=301, ccd=4, quad=3, minobs=20, skip=0, limit=10000):
@@ -267,16 +197,18 @@ def get_field_ids(catalog, field=301, ccd=4, quad=3, minobs=20, skip=0, limit=10
     r = gloria.query(q)
     data = r.get('data')
     return [data[i]['_id'] for i in range(len(data))]
-    # return list(map(lambda d: d['_id'], data))
 
 
 if __name__ == "__main__":
     DEFAULT_FIELD = 301
     DEFAULT_CCD = 4
     DEFAULT_QUAD = 3
+    DEFAULT_CCD_RANGE = [1, 16]
+    DEFAULT_QUAD_RANGE = [1, 4]
     DEFAULT_MINOBS = 20
-    DEFAULT_LIMIT = 10
+    DEFAULT_LIMIT = 10000
     DEFAULT_SKIP = 0
+    DEFAULT_VERBOSE = 2
 
     # pass Fritz token through secrets.json or as a command line argument
     with open(os.path.join(BASE_DIR, 'secrets.json'), 'r') as f:
@@ -302,13 +234,6 @@ if __name__ == "__main__":
         help="relative directory path to save output files to",
     )
 
-    token_help = "put your Fritz token here or in the secrets file.\
-                    You can get it from your Fritz profile page. This becomes\
-                    an optional parameter if put in secrets file."
-    if 'token' not in secrets['gloria'] or secrets['gloria']['token'] == "":
-        if '-token' not in sys.argv:
-            parser.add_argument("token", type=str, help=token_help)
-    parser.add_argument("--token", type=str, help=token_help)
     parser.add_argument(
         "--field", type=int, default=DEFAULT_FIELD, help="field number (default 301)"
     )
@@ -321,14 +246,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--ccd-range",
         type=int,
-        default=16,
-        help="ccd range from 1 to ccd_range (default 16, i.e. default range is [1,16])",
+        nargs='+',
+        default=DEFAULT_CCD_RANGE,
+        help="ccd range, two ints between 1 and 16 (default range is [1,16])",
     )
     parser.add_argument(
         "--quad-range",
         type=int,
-        default=4,
-        help="quad range from 1 to quad_range (default 4, i.e. default range is [1,4])",
+        nargs='+',
+        default=DEFAULT_QUAD_RANGE,
+        help="quad range, two ints between 1 and 4 (default range is [1,4])",
     )
     parser.add_argument(
         "--minobs",
@@ -337,30 +264,31 @@ if __name__ == "__main__":
         help="minimum number of points in light curve (default 20)",
     )
     parser.add_argument(
-        "--skip", type=int, default=0, help="number of rows to skip (default 0)"
+        "--skip",
+        type=int,
+        default=DEFAULT_SKIP,
+        help="number of rows to skip (default 0)",
     )
     parser.add_argument(
         "--limit",
         type=int,
-        default=10000,
+        default=DEFAULT_LIMIT,
         help="number of rows to return (default 10000)",
     )
     parser.add_argument(
         "--verbose",
         type=int,
-        default=2,
+        default=DEFAULT_VERBOSE,
         help="verbose level: 0=silent, 1=basic, 2=full",
     )
     parser.add_argument(
-        "--all-quads",
+        "--multi-quads",
         action="store_true",
-        default=True,
-        help="if passed as argument, get ids from all 64 quads for a particular field",
+        help="if passed as argument, get ids from multiple quads for a particular field and save in separate files",
     )
     parser.add_argument(
         "--whole-field",
         action="store_true",
-        default=True,
         help="if passed as argument, store all ids of the field in one file",
     )
 
@@ -371,43 +299,31 @@ if __name__ == "__main__":
         output_dir = "../ids/field_" + str(args.field) + "/"
     else:
         output_dir = args.output_dir + "/ids/field_" + str(args.field) + "/"
+    os.makedirs(output_dir, exist_ok=True)
 
-    # setup connection to gloria to get the lightcurves
-    if args.token:
-        secrets['gloria']['token'] = args.token
-    gloria = Kowalski(**secrets['gloria'], verbose=False)
-
-    #    data = get_field_ids(catalog='ZTF_sources_20210401',limit=args.limit)
-    # print(data)
-
-    if args.all_quads:
-        if not args.whole_field:
-            get_all_ids(
-                get_field_ids,
-                catalog=args.catalog,
-                field=args.field,
-                ccd_range=args.ccd_range,
-                quad_range=args.quad_range,
-                minobs=args.minobs,
-                limit=args.limit,
-                verbose=args.verbose,
-                output_dir=os.path.join(os.path.dirname(__file__), output_dir),
-            )
+    if (args.multi_quads) | (args.whole_field):
+        if args.whole_field:
+            print('Saving single file for entire field across ccd/quadrant range.')
         else:
-            get_all_field_ids(
-                get_field_ids,
-                catalog=args.catalog,
-                field=args.field,
-                ccd_range=args.ccd_range,
-                quad_range=args.quad_range,
-                minobs=args.minobs,
-                limit=args.limit,
-                verbose=args.verbose,
-                output_dir=os.path.join(os.path.dirname(__file__), output_dir),
-            )
+            print('Saving multiple files for each ccd/quadrant pair.')
+        get_ids(
+            get_field_ids,
+            catalog=args.catalog,
+            field=args.field,
+            ccd_range=args.ccd_range,
+            quad_range=args.quad_range,
+            minobs=args.minobs,
+            limit=args.limit,
+            verbose=args.verbose,
+            output_dir=os.path.join(os.path.dirname(__file__), output_dir),
+            whole_field=args.whole_field,
+        )
 
     else:
-        data, _ = get_field_ids(
+        print(
+            f'Saving up to {args.limit} results for single ccd/quadrant pair, skipping {args.skip} rows.'
+        )
+        data = get_field_ids(
             catalog=args.catalog,
             field=args.field,
             ccd=args.ccd,
@@ -416,4 +332,18 @@ if __name__ == "__main__":
             skip=args.skip,
             limit=args.limit,
         )
-        pd.DataFrame(data).to_csv(args.output, index=False, header=False)
+        print(f"Found {len(data)} results to save.")
+        pd.DataFrame(data).to_csv(
+            os.path.join(
+                output_dir,
+                "data_ccd_"
+                + str(args.ccd)
+                + "_quad_"
+                + str(args.quad)
+                + "_field_"
+                + str(args.field)
+                + ".csv",
+            ),
+            index=False,
+            header=False,
+        )


### PR DESCRIPTION
This PR consolidates two wrapper functions into one within get_quad_ids.py. It also modifies the usage of the script with the following changes:
- The `--whole-field` and `-all-quads` (now `-multi-quads`) keywords are no longer constantly `True`. They both default to `False` if not included in the script call.
- The `--ccd-range` and `--quad-range` keywords take two integers to allow ranges not starting at 1.
- Kowalski token authentication no longer requires secrets.json, using config.yaml instead
- More status updates printed during run
- `#!/usr/bin/env python` allows running the script with `./`