### PR TITLE
Fix ellipsoidal label in mapper

### DIFF
--- a/tools/golden_dataset_mapper.json
+++ b/tools/golden_dataset_mapper.json
@@ -259,7 +259,7 @@
       "taxonomy_id": 1011
     },
 
-"elliptical":
+"ellipsoidal":
     {"fritz_label": "ellipsoidal",
       "taxonomy_id": 1012
     },


### PR DESCRIPTION
The original golden dataset had a column labeled 'elliptical' which after inspection appears to describe ellipsoidal variables. The mapper between the dataset and Fritz previously contained the original column name, but with the dataset now uploaded to Fritz we can correct the column name in this PR. Future downloads from Fritz will produce an 'ellipsoidal' column.