### PR TITLE
Add versioning

### DIFF
--- a/scope/__init__.py
+++ b/scope/__init__.py
@@ -1,2 +1,36 @@
 from .nn import *
 from .utils import *
+
+__version__ = '0.2.dev0'
+
+if 'dev' in __version__:
+    # Append last commit date and hash to dev version information, if available
+
+    import subprocess
+    import os.path
+
+    try:
+        p = subprocess.Popen(
+            ['git', 'log', '-1', '--format="%h %aI"'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=os.path.dirname(__file__),
+        )
+    except FileNotFoundError:
+        pass
+    else:
+        out, err = p.communicate()
+        if p.returncode == 0:
+            git_hash, git_date = (
+                out.decode('utf-8')
+                .strip()
+                .replace('"', '')
+                .split('T')[0]
+                .replace('-', '')
+                .split()
+            )
+
+            __version__ = '+'.join(
+                [tag for tag in __version__.split('+') if not tag.startswith('git')]
+            )
+            __version__ += f'+git{git_date}.{git_hash}'

--- a/scope/__init__.py
+++ b/scope/__init__.py
@@ -2,6 +2,7 @@ from .nn import *
 from .utils import *
 
 # Below code adapted from https://github.com/skyportal/skyportal/blob/main/skyportal/__init__.py
+# 10-18-2022
 __version__ = '0.2.dev0'
 
 if 'dev' in __version__:

--- a/scope/__init__.py
+++ b/scope/__init__.py
@@ -1,6 +1,7 @@
 from .nn import *
 from .utils import *
 
+# Below code adapted from https://github.com/skyportal/skyportal/blob/main/skyportal/__init__.py
 __version__ = '0.2.dev0'
 
 if 'dev' in __version__:


### PR DESCRIPTION
This PR adds versioning to `scope/__init__.py` based on code adapted from [this file](https://github.com/skyportal/skyportal/blob/main/skyportal/__init__.py) in SkyPortal. I think a logical initial version is 0.2.dev0, recognizing development since the initiation of the project. The current git commit hash is also included for further version detail.

The broader goal is to include the code version in a header attached to downloaded training sets (#130).