### PR TITLE
Add support for HDF5, Parquet formats

### DIFF
--- a/.requirements/dev.txt
+++ b/.requirements/dev.txt
@@ -2,10 +2,7 @@ deepdiff>=5.0
 gsutil>=4.60
 keras-tuner>=1.0.2
 matplotlib>=3.3
-numpy<1.20
 pytest>=6.1.2
 questionary>=1.8.1
 scikit-learn>=0.24.1
-tensorflow<2.6
-tensorflow-addons>=0.12
 wandb>=0.12.1

--- a/.requirements/dev.txt
+++ b/.requirements/dev.txt
@@ -2,7 +2,10 @@ deepdiff>=5.0
 gsutil>=4.60
 keras-tuner>=1.0.2
 matplotlib>=3.3
+numpy<1.20
 pytest>=6.1.2
 questionary>=1.8.1
 scikit-learn>=0.24.1
+tensorflow<2.6
+tensorflow-addons>=0.12
 wandb>=0.12.1

--- a/.requirements/doc.txt
+++ b/.requirements/doc.txt
@@ -11,3 +11,4 @@ sphinx<3
 sphinx_press_theme
 tdtax>=0.1.3
 tables>=3.7
+pyarrow>=9.0.0

--- a/.requirements/doc.txt
+++ b/.requirements/doc.txt
@@ -10,3 +10,4 @@ pyyaml>=5.3.1
 sphinx<3
 sphinx_press_theme
 tdtax>=0.1.3
+tables>=3.7

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -89,6 +89,21 @@ done;
   ```
 * Creates a single `.csv` file containing all ids of the field in the rows and inference scores for different classes across the columns.
 
+## Handling different file formats
+When our manipulations of `pandas` dataframes is complete, we want to save them in an appropriate file format with the desired metadata. Our code works with multiple formats, each of which have advantages and drawbacks:
+
+- <b>Comma Separated Values (CSV, .csv):</b> in this format, data are plain text and columns are separated by commas. While this format offers a high level of human readability, it also takes more space to store and a longer time to write and read than other formats.
+
+  `pandas` offers the `read_csv()` function and `to_csv()` method to perform I/O operations with this format. Metadata must be included as plain text in the file.
+
+- <b>Hierarchical Data Format (HDF5, .h5):</b> this format stores data in binary form, so it is not human-readable. It takes up less space on disk than CSV files, and it writes/reads faster for numerical data. HDF5 does not serialize data columns containing structures like a `numpy` array, so file size improvements over CSV can be diminished if these structures exist in the data.
+
+  `pandas` includes `read_hdf()` and `to_hdf()` to handle this format, and they require a package like [`PyTables`](https://www.pytables.org/) to work. `pandas` does not currently support the reading and writing of metadata using the above function and method. See `scope/utils.py` for code that handles metadata in HDF5 files.
+
+- <b>Apache Parquet (.parquet):</b> this format stores data in binary form like HDF5, so it is not human-readable. Like HDF5, Parquet also offers significant disk space savings over CSV. Unlike HDF5, Parquet supports structures like `numpy` arrays in data columns.
+
+  While `pandas` offers `read_parquet()` and `to_parquet()` to support this format (requiring e.g. [`PyArrow`](https://arrow.apache.org/docs/python/) to work), these again do not support the reading and writing of metadata associated with the dataframe.  See `scope/utils.py` for code that reads and writes metadata in Parquet files.
+
 
 ## Scope Download Classification
 inputs:
@@ -101,6 +116,7 @@ inputs:
 7. Filename of classification mapper
 8. Name of directory to save downloaded files
 9. Name of file containing merged classifications and features
+10. Output format of saved files, if not specified in (9). Must be one of .parquet, .h5, or .csv.
 
 process:
 1. if CSV file provided, query by object ids or ra, dec
@@ -113,7 +129,7 @@ process:
 output: data with new columns appended.
 
 ```sh
-./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000 -mapper_name golden_dataset_mapper.json -output_dir fritzDownload -output_filename merged_classifications_features.csv
+./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000 -mapper_name golden_dataset_mapper.json -output_dir fritzDownload -output_filename merged_classifications_features -output_format .parquet
 ```
 
 ## Scope Upload Classification

--- a/scope/__init__.py
+++ b/scope/__init__.py
@@ -1,2 +1,36 @@
 from .nn import *
 from .utils import *
+
+__version__ = '0.2.dev0'
+
+if 'dev' in __version__:
+    # Append last commit date and hash to dev version information, if available
+
+    import subprocess
+    import os.path
+
+    try:
+        p = subprocess.Popen(
+            ['git', 'log', '-1', '--format="%h %aI"'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=os.path.dirname(__file__),
+        )
+    except FileNotFoundError:
+        pass
+    else:
+        out, err = p.communicate()
+        if p.returncode == 0:
+            git_hash, git_date = (
+                out.decode('utf-8')
+                .strip()
+                .replace('"', '')
+                .split('T')[0]
+                .replace('-', '')
+                .split()
+            )
+
+            __version__ = '+'.join(
+                [tag for tag in __version__.split('+') if not tag.startswith('git')]
+            )
+            __version__ += f'+git{git_date}.{git_hash}'

--- a/scope/__init__.py
+++ b/scope/__init__.py
@@ -2,6 +2,7 @@ from .nn import *
 from .utils import *
 
 # Below code adapted from https://github.com/skyportal/skyportal/blob/main/skyportal/__init__.py
+# 10-18-2022
 __version__ = '0.2.dev0'
 
 if 'dev' in __version__:

--- a/scope/__init__.py
+++ b/scope/__init__.py
@@ -4,7 +4,7 @@ from .models import *
 from .fritz import *
 
 # Below code adapted from https://github.com/skyportal/skyportal/blob/main/skyportal/__init__.py
-# 10-18-2022
+# 2022-10-18
 __version__ = '0.2.dev0'
 
 if 'dev' in __version__:

--- a/scope/__init__.py
+++ b/scope/__init__.py
@@ -1,6 +1,7 @@
 from .nn import *
 from .utils import *
 
+# Below code adapted from https://github.com/skyportal/skyportal/blob/main/skyportal/__init__.py
 __version__ = '0.2.dev0'
 
 if 'dev' in __version__:

--- a/scope/__init__.py
+++ b/scope/__init__.py
@@ -1,5 +1,7 @@
 from .nn import *
 from .utils import *
+from .models import *
+from .fritz import *
 
 # Below code adapted from https://github.com/skyportal/skyportal/blob/main/skyportal/__init__.py
 # 10-18-2022

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -234,7 +234,7 @@ def merge_sources_features(
             store.get_storer('df').attrs.metadata = merged_set.attrs
     else:
         # parquet code adapted from https://towardsdatascience.com/saving-metadata-with-dataframes-71f51f558d8e
-        # [2022-10-19]
+        # 2022-10-19
         # Create tables
         table = pa.Table.from_pandas(merged_set)
         # Serialize metadata from DataFrame.attrs
@@ -284,7 +284,7 @@ def download_classification(
     # Check for appropriate output format
     output_file_extension = os.path.splitext(output_filename)[-1]
 
-    # If h5 or csv extension specified in output_filename, use that format for saving
+    # If parquet, h5 or csv extension specified in output_filename, use that format for saving
     output_format = (
         output_format
         if output_file_extension not in ['.parquet', '.h5', '.csv']
@@ -417,7 +417,7 @@ def download_classification(
             return merged_sources
 
     else:
-        # read in CSV or HDF5 file
+        # read in CSV, HDF5 or parquet file
         if file.endswith('.csv'):
             sources = pd.read_csv(file)
         elif file.endswith('.h5'):
@@ -438,7 +438,7 @@ def download_classification(
             except KeyError:
                 warnings.warn('Did not read metadata from parquet file.')
         else:
-            raise TypeError('Input file must be h5 or csv format.')
+            raise TypeError('Input file must be h5, csv or parquet format.')
 
         if start != 0:
             # continue from checkpoint


### PR DESCRIPTION
This PR adds support for reading and saving data produced by `scope_download_classification.py` in the HDF5 and Parquet formats. Both formats offer smaller size and faster I/O than the CSV format, which is still retained as an option for saving. However, the dictionaries/arrays of the `coordiantes`  and `dmdt` features from Kowalski are not supported by HDF5, which pickles these columns and thereby diminishes the space savings over CSV. With its support for columns of dictionary/array columns, Parquet is made the default format to save Fritz downloads and merged features.

The documentation has been updated with a discussion about these different formats, and it points to `scope/utils.py`, where four new read/write functions for HDF5 and Parquet are now included.

Note also that this PR updates the requirements in `doc.txt`, adding `tables>=3.7` for HDF5 support and `pyarrow<9.0.0` for Parquet. These new requirements have not broken my install of scope or its existing functionality, but I have only tested on an M1 Mac.