### PR TITLE
Write features as parquet file

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -84,7 +84,7 @@ done;
 * The commands for inference of the field `<field_number>` (in order)
   ```
   ./tools/get_quad_ids.py --field=<field_number> --whole-field
-  ./tools/get_features.py --field=<field_number>
+  ./tools/get_features.py --field=<field_number> --whole-field
   ./get_all_preds.sh <field_number>
   ```
 * Creates a single `.csv` file containing all ids of the field in the rows and inference scores for different classes across the columns.

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -133,13 +133,13 @@ def get_features(
             df1 = read_parquet(outfile + ".parquet")
             df2 = pd.concat([df1, df], axis=0)
             # df2.to_pickle(outfile + ".pkl")
-            write_parquet(outfile + ".parquet")
+            write_parquet(df2, outfile + ".parquet")
             df1 = pd.read_csv(outfile + ".csv")
             df2 = pd.concat([df1, df], axis=0)
             df2.to_csv(outfile + ".csv", index=False)
         else:
             # df.to_pickle(outfile + ".pkl")
-            write_parquet(outfile + ".parquet")
+            write_parquet(df, outfile + ".parquet")
             df.to_csv(outfile + ".csv", index=False)
 
         if verbose:

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -110,6 +110,7 @@ def get_features(
             print(id * limit, "done")
 
     df = pd.concat(df_collection, axis=0)
+    df.reset_index(drop=True, inplace=True)
     dmdt = np.vstack(dmdt_collection)
 
     # Add metadata
@@ -132,8 +133,18 @@ def get_features(
             # df1 = pd.read_pickle(outfile + ".pkl")
             df1 = read_parquet(outfile + ".parquet")
             df2 = pd.concat([df1, df], axis=0)
+            df2.reset_index(drop=True, inplace=True)
+            df2.attrs = df1.attrs
+
+            # Append metadata for resumed download
+            keys = [x for x in df.attrs.keys()]
+            for key in keys:
+                df.attrs[f'{key}_resumed'] = df.attrs.pop(key)
+            df2.attrs.update(df.attrs)
+
             # df2.to_pickle(outfile + ".pkl")
             write_parquet(df2, outfile + ".parquet")
+
             df1 = pd.read_csv(outfile + ".csv")
             df2 = pd.concat([df1, df], axis=0)
             df2.to_csv(outfile + ".csv", index=False)

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -44,7 +44,7 @@ def get_features(
     '''
 
     field = kwargs.get("field", 302)
-    write_results = kwargs.get("write_results", False)
+    write_results = kwargs.get("write_results", True)
 
     if not whole_field:
         ccd = kwargs.get("ccd", 1)

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -130,7 +130,6 @@ def get_features(
             and os.path.exists(outfile + ".parquet")
             and os.path.exists(outfile + ".csv")
         ):
-            # df1 = pd.read_pickle(outfile + ".pkl")
             df1 = read_parquet(outfile + ".parquet")
             df2 = pd.concat([df1, df], axis=0)
             df2.reset_index(drop=True, inplace=True)
@@ -142,14 +141,12 @@ def get_features(
                 df.attrs[f'{key}_resumed'] = df.attrs.pop(key)
             df2.attrs.update(df.attrs)
 
-            # df2.to_pickle(outfile + ".pkl")
             write_parquet(df2, outfile + ".parquet")
 
             df1 = pd.read_csv(outfile + ".csv")
             df2 = pd.concat([df1, df], axis=0)
             df2.to_csv(outfile + ".csv", index=False)
         else:
-            # df.to_pickle(outfile + ".pkl")
             write_parquet(df, outfile + ".parquet")
             df.to_csv(outfile + ".csv", index=False)
 

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -9,6 +9,8 @@ import yaml
 import os
 import time
 import h5py
+from scope.utils import read_parquet, write_parquet
+from datetime import datetime
 
 BASE_DIR = os.path.dirname(__file__)
 JUST = 50
@@ -42,7 +44,7 @@ def get_features(
     '''
 
     field = kwargs.get("field", 302)
-    write_results = kwargs.get("write_results", True)
+    write_results = kwargs.get("write_results", False)
 
     if not whole_field:
         ccd = kwargs.get("ccd", 1)
@@ -110,6 +112,13 @@ def get_features(
     df = pd.concat(df_collection, axis=0)
     dmdt = np.vstack(dmdt_collection)
 
+    # Add metadata
+    utcnow = datetime.utcnow()
+    start_dt = utcnow.strftime("%Y-%m-%d %H:%M:%S")
+    features_ztf_dr = features_catalog.split('_')[-1]
+    df.attrs['features_download_dateTime_utc'] = start_dt
+    df.attrs['features_ztf_dataRelease'] = features_ztf_dr
+
     if not write_results:
         return df, dmdt
 
@@ -117,22 +126,27 @@ def get_features(
         os.makedirs(os.path.dirname(outfile), exist_ok=True)
         if (
             restart is False
-            and os.path.exists(outfile + ".pkl")
+            and os.path.exists(outfile + ".parquet")
             and os.path.exists(outfile + ".csv")
         ):
-            df1 = pd.read_pickle(outfile + ".pkl")
+            # df1 = pd.read_pickle(outfile + ".pkl")
+            df1 = read_parquet(outfile + ".parquet")
             df2 = pd.concat([df1, df], axis=0)
-            df2.to_pickle(outfile + ".pkl")
+            # df2.to_pickle(outfile + ".pkl")
+            write_parquet(outfile + ".parquet")
             df1 = pd.read_csv(outfile + ".csv")
             df2 = pd.concat([df1, df], axis=0)
             df2.to_csv(outfile + ".csv", index=False)
         else:
-            df.to_pickle(outfile + ".pkl")
+            # df.to_pickle(outfile + ".pkl")
+            write_parquet(outfile + ".parquet")
             df.to_csv(outfile + ".csv", index=False)
 
         if verbose:
             print("Features dataframe: ", df)
             print("dmdt shape: ", dmdt.shape)
+
+    return df, dmdt
 
 
 def run(**kwargs):
@@ -163,7 +177,7 @@ def run(**kwargs):
     =======
     Stores the features in a file at the following location:
         features/field_<field>/field_<field>.csv
-    and features/field_<field>/field_<field>.pkl
+    and features/field_<field>/field_<field>.parquet
     """
 
     DEFAULT_FIELD = 291

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -296,7 +296,9 @@ if __name__ == "__main__":
 
     # Set default output directory
     if args.output_dir is None:
-        output_dir = "../ids/field_" + str(args.field) + "/"
+        output_dir = os.path.join(
+            os.path.dirname(__file__), "../ids/field_" + str(args.field) + "/"
+        )
     else:
         output_dir = args.output_dir + "/ids/field_" + str(args.field) + "/"
     os.makedirs(output_dir, exist_ok=True)

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -295,8 +295,6 @@ def run(
 
     # get raw features
     ts = time.time()
-    # features = pd.read_csv(features_filename+".csv")
-    # features = pd.read_pickle(features_filename + ".pkl")
     features = read_parquet(features_filename + '.parquet')
     feature_stats = config.get("feature_stats", None)
     te = time.time()

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -14,6 +14,7 @@ import os
 import time
 import h5py
 from scope import nn
+from scope.utils import read_parquet
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 warnings.filterwarnings('ignore')
@@ -295,7 +296,8 @@ def run(
     # get raw features
     ts = time.time()
     # features = pd.read_csv(features_filename+".csv")
-    features = pd.read_pickle(features_filename + ".pkl")
+    # features = pd.read_pickle(features_filename + ".pkl")
+    features = read_parquet(features_filename + '.parquet')
     feature_stats = config.get("feature_stats", None)
     te = time.time()
     if tm:

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -199,17 +199,13 @@ def merge_sources_features(
 
     # Merge on ZTF id
     merged_set = pd.merge(expanded_sources, df, on='ztf_id')
-    merged_set.attrs = sources.attrs
+    source_metadata = sources.attrs
+    source_metadata.update(df.attrs)
+    merged_set.attrs = source_metadata
 
     # Make ztf_id last column in dataframe
     ztf_id_col = merged_set.pop('ztf_id')
     merged_set['ztf_id'] = ztf_id_col
-
-    # Add more metadata
-    utcnow = datetime.utcnow()
-    start_dt = utcnow.strftime("%Y-%m-%d %H:%M:%S")
-    merged_set.attrs['features_download_dateTime_utc'] = start_dt
-    merged_set.attrs['features_ztf_dataRelease'] = features_ztf_dr
 
     filepath = os.path.join(outpath, output_filename + output_format)
     if output_format == '.csv':


### PR DESCRIPTION
This PR saves features from Kowalski in parquet format instead of pickle, optimizing disk space. Metadata for the feature download is now generated within get_features.py rather than scope_download_classification.py. The parquet file is also supported as an input to inference.py.

During my testing of this new code, I removed a remaining relative filepath in get_quad_ids.py. I also tweaked the documentation for running get_features.py.