### PR TITLE
Add Parquet, HDF5 support to Dataset class

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -489,7 +489,7 @@ class Scope:
         """Train classifier
 
         :param tag: classifier designation, refers to "class" in config.taxonomy
-        :param path_dataset: local path to csv file with the dataset
+        :param path_dataset: local path to .parquet, .h5 or .csv file with the dataset
         :param gpu: GPU id to use, zero-based. check tf.config.list_physical_devices('GPU') for available devices
         :param verbose:
         :param kwargs: refer to utils.DNN.setup and utils.Dataset.make

--- a/scope/utils.py
+++ b/scope/utils.py
@@ -518,31 +518,29 @@ class Dataset(object):
         :param features:
         :param verbose:
         """
-        self.verbose = verbose
-
         self.tag = tag
+        self.path_dataset = str(path_dataset)
         self.features = features
-
+        self.verbose = verbose
         self.target = None
 
         if self.verbose:
-            log(f"Loading {path_dataset}...")
+            log(f"Loading {self.path_dataset}...")
         nrows = kwargs.get("nrows", None)
 
-        path_dataset = str(path_dataset)
         csv = False
-        if path_dataset.endswith('.csv'):
+        if self.path_dataset.endswith('.csv'):
             csv = True
-            self.df_ds = pd.read_csv(path_dataset, nrows=nrows)
-        elif path_dataset.endswith('.h5'):
-            self.df_ds = read_hdf(path_dataset)
+            self.df_ds = pd.read_csv(self.path_dataset, nrows=nrows)
+        elif self.path_dataset.endswith('.h5'):
+            self.df_ds = read_hdf(self.path_dataset)
             for key in ['coordinates', 'dmdt']:
-                df_temp = read_hdf(path_dataset, key=key)
+                df_temp = read_hdf(self.path_dataset, key=key)
                 self.df_ds[key] = df_temp
             del df_temp
             self.dmdt = self.df_ds['dmdt']
-        elif path_dataset.endswith('.parquet'):
-            self.df_ds = read_parquet(path_dataset)
+        elif self.path_dataset.endswith('.parquet'):
+            self.df_ds = read_parquet(self.path_dataset)
             self.dmdt = self.df_ds['dmdt']
         else:
             raise ValueError('Dataset must have .parquet, .h5 or .csv extension.')

--- a/scope/utils.py
+++ b/scope/utils.py
@@ -511,7 +511,6 @@ class Dataset(object):
         **kwargs,
     ):
         """Load parquet, hdf5 or csv file with the dataset containing both data and labels
-        As of 20221025, it is produced by scope_download_classification.py
 
         :param tag:
         :param path_dataset:


### PR DESCRIPTION
This PR enables .parquet and .h5 files to be read by the `Dataset` class, which is used during training.