### PR TITLE
Add group_ids to photometry json

### DIFF
--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -344,6 +344,7 @@ def save_newsource(
         "filter": df_photometry["ztf_filter"].tolist(),
         "ra": df_photometry["ra"].tolist(),
         "dec": df_photometry["dec"].tolist(),
+        "group_ids": group_ids,
     }
 
     if (len(photometry.get("mag", ())) > 0) & (not dryrun):


### PR DESCRIPTION
This PR adds the `group_ids` keyword to the photometry JSON object that gets uploaded to Fritz. This change will allow photometry to be seen by members of the groups specified by this keyword.