### PR TITLE
Add custom keywords to training script

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -77,6 +77,14 @@ for class in pnp longt i fla ew eb ea e agn bis blyr ceph dscu lpv mir puls rrly
   done; \
 done;
 ```
+
+A training script can also be generated using `./scope.py create_training_script`, for example:
+```bash
+./scope.py create_training_script --filename='train_dnn.sh' --min_count=100 --add_keywords='--save --batch_size=32'
+```
+A path to the training set may be provided as input to this method or taken from `config.yaml` (`training: dataset:`).
+
+
 ## Running inference
 
 * Inference requires the following steps: download ids of a field, download features for all downloaded ids, run inference for all available pre-trained models.

--- a/scope.py
+++ b/scope.py
@@ -696,6 +696,7 @@ class Scope:
         filename: str = 'train_dnn.sh',
         min_count: int = 100,
         path_dataset: str = None,
+        add_keywords: str = '',
     ):
         """
         Create training shell script from classes in config file meeting minimum count requirement
@@ -703,6 +704,8 @@ class Scope:
         :param filename: filename of shell script (must not currently exist) (str)
         :param min_count: minimum number of positive examples to include in script (int)
         :param path_dataset: local path to .parquet, .h5 or .csv file with the dataset, if not provided in config.yaml (str)
+        :param more_keywords: str containing additional training keywords to append to each line in the script
+
         :return:
         """
         path = str(pathlib.Path(__file__).parent.absolute() / filename)
@@ -733,11 +736,11 @@ class Scope:
                 threshold = self.config['training']['classes'][key]['threshold']
                 branch = self.config['training']['classes'][key]['features']
                 num_pos = np.sum(dataset[label] > threshold)
-                print(
-                    f'Label {label}: {num_pos} positive examples with P > {threshold}'
-                )
 
                 if num_pos > min_count:
+                    print(
+                        f'Label {label}: {num_pos} positive examples with P > {threshold}'
+                    )
                     if branch == 'phenomenological':
                         phenom_keys += [key]
                     else:
@@ -746,14 +749,14 @@ class Scope:
             script.write('# Phenomenological\n')
             script.writelines(
                 [
-                    f'./scope.py train --tag {key} --path_dataset {path_dataset} --verbose \n'
+                    f'./scope.py train --tag {key} --path_dataset {path_dataset} --verbose {add_keywords} \n'
                     for key in phenom_keys
                 ]
             )
             script.write('# Ontological\n')
             script.writelines(
                 [
-                    f'./scope.py train --tag {key} --path_dataset {path_dataset} --verbose \n'
+                    f'./scope.py train --tag {key} --path_dataset {path_dataset} --verbose {add_keywords} \n'
                     for key in ontol_keys
                 ]
             )

--- a/scope.py
+++ b/scope.py
@@ -707,6 +707,12 @@ class Scope:
         :param add_keywords: str containing additional training keywords to append to each line in the script
 
         :return:
+
+        :examples:  ./scope.py create_training_script --filename='train_dnn.sh' --min_count=1000 \
+                    --path_dataset='tools/fritzDownload/merged_classifications_features.parquet' --add_keywords='--save'
+
+                    ./scope.py create_training_script --filename='train_dnn.sh' --min_count=100 \
+                    --add_keywords='--save --batch_size=32'
         """
         path = str(pathlib.Path(__file__).parent.absolute() / filename)
         phenom_keys = []

--- a/scope.py
+++ b/scope.py
@@ -704,7 +704,7 @@ class Scope:
         :param filename: filename of shell script (must not currently exist) (str)
         :param min_count: minimum number of positive examples to include in script (int)
         :param path_dataset: local path to .parquet, .h5 or .csv file with the dataset, if not provided in config.yaml (str)
-        :param more_keywords: str containing additional training keywords to append to each line in the script
+        :param add_keywords: str containing additional training keywords to append to each line in the script
 
         :return:
         """


### PR DESCRIPTION
This PR allows custom keywords to be appended in bulk to the training script generated using `./scope.py create_training_script`. The usage documentation is also updated to mention this method.