### PR TITLE
Save/load trained models consistently

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -84,6 +84,7 @@ A training script can also be generated using `./scope.py create_training_script
 ```
 A path to the training set may be provided as input to this method or taken from `config.yaml` (`training: dataset:`).
 
+If `--save` is specified during training, an HDF5 file of the model's layers and weights will be saved. This file can be directly used for inferencing.
 
 ## Running inference
 

--- a/scope.py
+++ b/scope.py
@@ -772,7 +772,6 @@ class Scope:
         :return:
         """
         import uuid
-        import shutil
 
         # create a mock dataset and check that the training pipeline works
         dataset = f"{uuid.uuid4().hex}.csv"
@@ -818,9 +817,12 @@ class Scope:
                 test=True,
             )
             path_model = (
-                pathlib.Path(__file__).parent.absolute() / "models" / tag / time_tag
+                pathlib.Path(__file__).parent.absolute()
+                / "models"
+                / tag
+                / f"{tag}.{time_tag}.h5"
             )
-            shutil.rmtree(path_model)
+            os.remove(path_model)
         finally:
             # clean up after thyself
             (path_mock / dataset).unlink()

--- a/scope.py
+++ b/scope.py
@@ -16,7 +16,6 @@ import tdtax
 from tdtax import taxonomy  # noqa: F401
 from typing import Optional, Sequence, Union
 import yaml
-
 from scope.utils import forgiving_true, load_config, read_hdf, read_parquet
 
 

--- a/scope.py
+++ b/scope.py
@@ -685,7 +685,7 @@ class Scope:
                 print(f"Saving model to {output_path}")
             classifier.save(
                 output_path=output_path,
-                output_format="tf",
+                output_format="h5",
                 tag=time_tag,
             )
 

--- a/scope/nn.py
+++ b/scope/nn.py
@@ -411,4 +411,4 @@ class DNN(AbstractClassifier):
         output_name = self.name if not tag else f"{self.name}.{tag}"
         if not output_name.endswith('.h5'):
             output_name += '.h5'
-        self.model.save_weights(path / output_name, save_format=output_format)
+        self.model.save_model(path / output_name, save_format=output_format)

--- a/scope/nn.py
+++ b/scope/nn.py
@@ -398,16 +398,17 @@ class DNN(AbstractClassifier):
         self,
         tag: str,
         output_path: str = "./",
-        output_format: str = "tf",
+        output_format: str = "h5",
     ):
 
-        if output_format not in ("tf",):
+        if output_format not in ("h5",):
             raise ValueError("unknown output format")
-
-        output_name = self.name if not tag else f"{self.name}.{tag}"
 
         path = pathlib.Path(output_path)
         if not path.exists():
             path.mkdir(parents=True, exist_ok=True)
 
-        self.model.save_weights(path / tag / output_name, save_format="tf")
+        output_name = self.name if not tag else f"{self.name}.{tag}"
+        if not output_name.endswith('.h5'):
+            output_name += '.h5'
+        self.model.save_weights(path / output_name, save_format=output_format)

--- a/scope/nn.py
+++ b/scope/nn.py
@@ -411,4 +411,4 @@ class DNN(AbstractClassifier):
         output_name = self.name if not tag else f"{self.name}.{tag}"
         if not output_name.endswith('.h5'):
             output_name += '.h5'
-        self.model.save_model(path / output_name, save_format=output_format)
+        self.model.save(path / output_name, save_format=output_format)

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import tensorflow as tf
 import fire
 import numpy as np
 import pandas as pd
@@ -12,7 +13,6 @@ import json
 import os
 import time
 import h5py
-from scope import nn
 from scope.utils import read_parquet
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
@@ -339,10 +339,7 @@ def run(
 
         # Load pre-trained model
         ts = time.time()
-        model = nn.DNN.build_model(features_input_shape=(len(feature_names),))
-        if verbose:
-            print(model.summary())
-        model.load_weights(path_model)
+        model = tf.keras.models.load_model(path_model)
         te = time.time()
         if tm:
             print(

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import tensorflow as tf
 import fire
 import numpy as np
 import pandas as pd
@@ -340,14 +339,10 @@ def run(
 
         # Load pre-trained model
         ts = time.time()
-        if str(path_model).endswith(".h5"):
-            model = tf.keras.models.load_model(path_model)
-        else:
-            # model = make_model(features_input_shape=(len(feature_names),)) # Use this line if performing inference with old model
-            model = nn.DNN.build_model(features_input_shape=(len(feature_names),))
-            if verbose:
-                print(model.summary())
-            model.load_weights(path_model).expect_partial()
+        model = nn.DNN.build_model(features_input_shape=(len(feature_names),))
+        if verbose:
+            print(model.summary())
+        model.load_weights(path_model)
         te = time.time()
         if tm:
             print(


### PR DESCRIPTION
This PR simplifies the saving and loading of trained DNN models, which now uniformly use HDF5 format. There was previously an inconsistency between the use of tensorflow format for saving weights (without layers) after training and HDF5 format for loading weights and/or layers before inference. Although saving the weights and layers together takes up more disk space, this approach avoids potential confusion if layers of the model change over time.