### PR TITLE
Fix dmdt inference bug

### DIFF
--- a/tools/inference.py
+++ b/tools/inference.py
@@ -306,7 +306,9 @@ def run(
         )
 
     if not xgbst:
-        dmdt = np.expand_dims(np.array([d for d in features['dmdt'].values]), axis=-1)
+        dmdt = np.expand_dims(
+            np.array([d for d in features['dmdt'].apply(list).values]), axis=-1
+        )
 
         # scale features
         ts = time.time()


### PR DESCRIPTION
This PR fixes a bug when performing inference using a .parquet features file. Unlike the previous pickle format, loading the parquet file changes python lists to numpy arrays. This raised a tensorflow error when passing dmdt into model.predict().