### PR TITLE
Checkpoint feature downloads

### DIFF
--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -41,7 +41,7 @@ def get_features_loop(
     ccd: int = 1,
     quad: int = 1,
     limit_per_query: int = 1000,
-    max_sources: int = 500000,
+    max_sources: int = 100000,
     restart: bool = True,
     write_csv: bool = False,
 ):
@@ -225,7 +225,7 @@ def run(**kwargs):
     DEFAULT_CCD = 1
     DEFAULT_QUAD = 1
     DEFAULT_LIMIT = 1000
-    DEFAULT_SAVE_BATCHSIZE = 500000
+    DEFAULT_SAVE_BATCHSIZE = 100000
     DEFAULT_CATALOG = "ZTF_source_features_DR5"
 
     field = kwargs.get("field", DEFAULT_FIELD)

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -37,11 +37,11 @@ def get_features_loop(
     features_catalog: str = "ZTF_source_features_DR5",
     verbose: bool = False,
     whole_field: bool = True,
-    field: int = 302,
+    field: int = 291,
     ccd: int = 1,
     quad: int = 1,
     limit_per_query: int = 1000,
-    max_sources: int = 1000000,
+    max_sources: int = 500000,
     restart: bool = True,
     write_csv: bool = False,
 ):
@@ -225,7 +225,7 @@ def run(**kwargs):
     DEFAULT_CCD = 1
     DEFAULT_QUAD = 1
     DEFAULT_LIMIT = 1000
-    DEFAULT_SAVE_BATCHSIZE = 2000
+    DEFAULT_SAVE_BATCHSIZE = 500000
     DEFAULT_CATALOG = "ZTF_source_features_DR5"
 
     field = kwargs.get("field", DEFAULT_FIELD)

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -191,8 +191,7 @@ def merge_sources_features(
     df, dmdt = get_features(
         source_ids=source_ids,
         features_catalog=features_catalog,
-        limit=features_limit,
-        write_results=False,
+        limit_per_query=features_limit,
     )
     df['ztf_id'] = df['_id']
     df = df.drop(['_id'], axis=1)
@@ -534,7 +533,7 @@ def download_classification(
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-file", help="dataset")
+    parser.add_argument("-file", type=str, default='parse', help="dataset")
     parser.add_argument("-group_ids", type=int, nargs='+', help="list of group ids")
     parser.add_argument(
         "-start", type=int, default=0, help="start page/index for continued download"


### PR DESCRIPTION
This PR refactors get_features.py to enable checkpoint saving for large feature downloads. For fields with millions of sources, the feature downloads often freeze and fail. This new code (mainly the `get_features_loop` wrapper) writes features to a parquet file (CSV optional) for every 100,000 sources by default. If the download is cut off, the user can re-run the same code to continue downloading from the last checkpoint.

The existing use of get_features.py code in scope_download_classification.py is tested and adjusted to continue working properly.