### PR TITLE
Add readme instruction for generating docs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![arXiv](https://img.shields.io/badge/arXiv-2102.11304-brightgreen)](https://arxiv.org/abs/2102.11304)
 [![arXiv](https://img.shields.io/badge/arXiv-2009.14071-brightgreen)](https://arxiv.org/abs/2009.14071)
 
-The documentation is hosted at [https://scope.ztf.dev](https://scope.ztf.dev). To generate an HTML file of the documentation locally, run `./scope.py doc`
+The documentation is hosted at [https://scope.ztf.dev](https://scope.ztf.dev). To generate HTML files of the documentation locally, run `./scope.py doc`

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![arXiv](https://img.shields.io/badge/arXiv-2102.11304-brightgreen)](https://arxiv.org/abs/2102.11304)
 [![arXiv](https://img.shields.io/badge/arXiv-2009.14071-brightgreen)](https://arxiv.org/abs/2009.14071)
 
-The documentation is hosted at [https://scope.ztf.dev](https://scope.ztf.dev).
+The documentation is hosted at [https://scope.ztf.dev](https://scope.ztf.dev). To generate an HTML file of the documentation locally, run `./scope.py doc`


### PR DESCRIPTION
This PR updates README.md to include how to generate local HTML documentation since scope.ztf.dev is down.