### PR TITLE
Loop over multiple parquet feature files during inference

### DIFF
--- a/tools/inference.py
+++ b/tools/inference.py
@@ -245,9 +245,7 @@ def run(
         default_source_file = (
             BASE_DIR + "/../ids/field_" + str(field) + "/field_" + str(field) + ".h5"
         )
-        default_features_file = (
-            BASE_DIR + "/../features/field_" + str(field)  # + "/field_" + str(field)
-        )
+        default_features_file = BASE_DIR + "/../features/field_" + str(field)
     else:
         default_source_file = (
             BASE_DIR


### PR DESCRIPTION
This PR modifies inference.py to loop over the contents of multiple parquet files containing a field's features. The new code requires much less memory without a major increase in inference time. 