### PR TITLE
Restructure features lists in config defaults

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -771,6 +771,16 @@ features:
     PS1_DR1__zMeanPSFMagErr:
       include: true
       dtype: float
+    _id:
+      include: false
+      dtype: int
+    coordinates:
+      include: false
+      dtype: object
+    # This feature is included separately by nn.py, but the dtype is specified here for get_features.py
+    dmdt:
+      include: false
+      dtype: object
 
 feature_stats:
   # d15-based

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -392,133 +392,385 @@ features:
     - PS1_DR1__yMeanPSFMag
     - PS1_DR1__yMeanPSFMagErr
   phenomenological:
-    - ad
-#    - ccd
-    - chi2red
-#    - dec
-    - f1_BIC
-    - f1_a
-    - f1_amp
-    - f1_b
-    - f1_phi0
-    - f1_power
-    - f1_relamp1
-    - f1_relamp2
-    - f1_relamp3
-    - f1_relamp4
-    - f1_relphi1
-    - f1_relphi2
-    - f1_relphi3
-    - f1_relphi4
-    - field
-    - i60r
-    - i70r
-    - i80r
-    - i90r
-    - inv_vonneumannratio
-    - iqr
-    - mean_ztf_alert_braai
-    - median
-    - median_abs_dev
-#    - n
-    - n_ztf_alerts
-    - norm_excess_var
-    - norm_peak_to_peak_amp
-#    - pdot
-    - period
-#    - quad
-#    - ra
-    - roms
-    - significance
-    - skew
-    - smallkurt
-    - stetson_j
-    - stetson_k
-    - sw
-    - welch_i
-    - wmean
-    - wstd
+    ad:
+      include: true
+      dtype: float
+    ccd:
+      include: false
+      dtype: int
+    chi2red:
+      include: true
+      dtype: float
+    dec:
+      include: false
+      dtype: float
+    f1_BIC:
+      include: true
+      dtype: float
+    f1_a:
+      include: true
+      dtype: float
+    f1_amp:
+      include: true
+      dtype: float
+    f1_b:
+      include: true
+      dtype: float
+    f1_phi0:
+      include: true
+      dtype: float
+    f1_power:
+      include: true
+      dtype: float
+    f1_relamp1:
+      include: true
+      dtype: float
+    f1_relamp2:
+      include: true
+      dtype: float
+    f1_relamp3:
+      include: true
+      dtype: float
+    f1_relamp4:
+      include: true
+      dtype: float
+    f1_relphi1:
+      include: true
+      dtype: float
+    f1_relphi2:
+      include: true
+      dtype: float
+    f1_relphi3:
+      include: true
+      dtype: float
+    f1_relphi4:
+      include: true
+      dtype: float
+    field:
+      include: false
+      dtype: int
+    i60r:
+      include: true
+      dtype: float
+    i70r:
+      include: true
+      dtype: float
+    i80r:
+      include: true
+      dtype: float
+    i90r:
+      include: true
+      dtype: float
+    inv_vonneumannratio:
+      include: true
+      dtype: float
+    iqr:
+      include: true
+      dtype: float
+    mean_ztf_alert_braai:
+      include: false
+      dtype: float
+    median:
+      include: true
+      dtype: float
+    median_abs_dev:
+      include: true
+      dtype: float
+    n:
+      include: false
+      dtype: float
+    n_ztf_alerts:
+      include: false
+      dtype: int
+    norm_excess_var:
+      include: true
+      dtype: float
+    norm_peak_to_peak_amp:
+      include: true
+      dtype: float
+    pdot:
+      include: false
+      dtype: float
+    period:
+      include: false
+      dtype: float
+    quad:
+      include: false
+      dtype: int
+    ra:
+      include: false
+      dtype: float
+    roms:
+      include: true
+      dtype: float
+    significance:
+      include: false
+      dtype: float
+    skew:
+      include: true
+      dtype: float
+    smallkurt:
+      include: true
+      dtype: float
+    stetson_j:
+      include: true
+      dtype: float
+    stetson_k:
+      include: true
+      dtype: float
+    sw:
+      include: true
+      dtype: float
+    welch_i:
+      include: true
+      dtype: float
+    wmean:
+      include: true
+      dtype: float
+    wstd:
+      include: true
+      dtype: float
   ontological:
-    - ad
-    - ccd
-    - chi2red
-    - dec
-    - f1_BIC
-    - f1_a
-    - f1_amp
-    - f1_b
-    - f1_phi0
-    - f1_power
-    - f1_relamp1
-    - f1_relamp2
-    - f1_relamp3
-    - f1_relamp4
-    - f1_relphi1
-    - f1_relphi2
-    - f1_relphi3
-    - f1_relphi4
-    - field
-    - i60r
-    - i70r
-    - i80r
-    - i90r
-    - inv_vonneumannratio
-    - iqr
-    - mean_ztf_alert_braai
-    - median
-    - median_abs_dev
-#    - n
-    - n_ztf_alerts
-    - norm_excess_var
-    - norm_peak_to_peak_amp
-#    - pdot
-    - period
-    - quad
-    - ra
-    - roms
-    - significance
-    - skew
-    - smallkurt
-    - stetson_j
-    - stetson_k
-    - sw
-    - welch_i
-    - wmean
-    - wstd
-#    - AllWISE___id
-#    - AllWISE__ph_qual
-    - AllWISE__w1mpro
-    - AllWISE__w1sigmpro
-    - AllWISE__w2mpro
-    - AllWISE__w2sigmpro
-    - AllWISE__w3mpro
-    - AllWISE__w3sigmpro
-    - AllWISE__w4mpro
-    - AllWISE__w4sigmpro
-#    - Gaia_EDR3___id
-    - Gaia_EDR3__astrometric_excess_noise
-    - Gaia_EDR3__parallax
-    - Gaia_EDR3__parallax_error
-    - Gaia_EDR3__phot_bp_mean_mag
-    - Gaia_EDR3__phot_bp_rp_excess_factor
-    - Gaia_EDR3__phot_g_mean_mag
-    - Gaia_EDR3__phot_rp_mean_mag
-    - Gaia_EDR3__pmdec
-    - Gaia_EDR3__pmdec_error
-    - Gaia_EDR3__pmra
-    - Gaia_EDR3__pmra_error
-#    - PS1_DR1___id
-    - PS1_DR1__gMeanPSFMag
-    - PS1_DR1__gMeanPSFMagErr
-    - PS1_DR1__iMeanPSFMag
-    - PS1_DR1__iMeanPSFMagErr
-    - PS1_DR1__qualityFlag
-    - PS1_DR1__rMeanPSFMag
-    - PS1_DR1__rMeanPSFMagErr
-    - PS1_DR1__yMeanPSFMag
-    - PS1_DR1__yMeanPSFMagErr
-    - PS1_DR1__zMeanPSFMag
-    - PS1_DR1__zMeanPSFMagErr
+    ad:
+      include: true
+      dtype: float
+    ccd:
+      include: false
+      dtype: int
+    chi2red:
+      include: true
+      dtype: float
+    dec:
+      include: false
+      dtype: float
+    f1_BIC:
+      include: true
+      dtype: float
+    f1_a:
+      include: true
+      dtype: float
+    f1_amp:
+      include: true
+      dtype: float
+    f1_b:
+      include: true
+      dtype: float
+    f1_phi0:
+      include: true
+      dtype: float
+    f1_power:
+      include: true
+      dtype: float
+    f1_relamp1:
+      include: true
+      dtype: float
+    f1_relamp2:
+      include: true
+      dtype: float
+    f1_relamp3:
+      include: true
+      dtype: float
+    f1_relamp4:
+      include: true
+      dtype: float
+    f1_relphi1:
+      include: true
+      dtype: float
+    f1_relphi2:
+      include: true
+      dtype: float
+    f1_relphi3:
+      include: true
+      dtype: float
+    f1_relphi4:
+      include: true
+      dtype: float
+    field:
+      include: false
+      dtype: int
+    i60r:
+      include: true
+      dtype: float
+    i70r:
+      include: true
+      dtype: float
+    i80r:
+      include: true
+      dtype: float
+    i90r:
+      include: true
+      dtype: float
+    inv_vonneumannratio:
+      include: true
+      dtype: float
+    iqr:
+      include: true
+      dtype: float
+    mean_ztf_alert_braai:
+      include: true
+      dtype: float
+    median:
+      include: true
+      dtype: float
+    median_abs_dev:
+      include: true
+      dtype: float
+    n:
+      include: false
+      dtype: float
+    n_ztf_alerts:
+      include: true
+      dtype: int
+    norm_excess_var:
+      include: true
+      dtype: float
+    norm_peak_to_peak_amp:
+      include: true
+      dtype: float
+    pdot:
+      include: false
+      dtype: float
+    period:
+      include: true
+      dtype: float
+    quad:
+      include: false
+      dtype: int
+    ra:
+      include: false
+      dtype: float
+    roms:
+      include: true
+      dtype: float
+    significance:
+      include: true
+      dtype: float
+    skew:
+      include: true
+      dtype: float
+    smallkurt:
+      include: true
+      dtype: float
+    stetson_j:
+      include: true
+      dtype: float
+    stetson_k:
+      include: true
+      dtype: float
+    sw:
+      include: true
+      dtype: float
+    welch_i:
+      include: true
+      dtype: float
+    wmean:
+      include: true
+      dtype: float
+    wstd:
+      include: true
+      dtype: float
+    AllWISE___id:
+      include: false
+      dtype: int
+    AllWISE__ph_qual:
+      include: false
+      dtype: str
+    AllWISE__w1mpro:
+      include: true
+      dtype: float
+    AllWISE__w1sigmpro:
+      include: true
+      dtype: float
+    AllWISE__w2mpro:
+      include: true
+      dtype: float
+    AllWISE__w2sigmpro:
+      include: true
+      dtype: float
+    AllWISE__w3mpro:
+      include: true
+      dtype: float
+    AllWISE__w3sigmpro:
+      include: true
+      dtype: float
+    AllWISE__w4mpro:
+      include: true
+      dtype: float
+    AllWISE__w4sigmpro:
+      include: true
+      dtype: float
+    Gaia_EDR3___id:
+      include: false
+      dtype: int
+    Gaia_EDR3__astrometric_excess_noise:
+      include: false
+      dtype: float
+    Gaia_EDR3__parallax:
+      include: true
+      dtype: float
+    Gaia_EDR3__parallax_error:
+      include: false
+      dtype: float
+    Gaia_EDR3__phot_bp_mean_mag:
+      include: true
+      dtype: float
+    Gaia_EDR3__phot_bp_rp_excess_factor:
+      include: true
+      dtype: float
+    Gaia_EDR3__phot_g_mean_mag:
+      include: true
+      dtype: float
+    Gaia_EDR3__phot_rp_mean_mag:
+      include: true
+      dtype: float
+    Gaia_EDR3__pmdec:
+      include: false
+      dtype: float
+    Gaia_EDR3__pmdec_error:
+      include: false
+      dtype: float
+    Gaia_EDR3__pmra:
+      include: false
+      dtype: float
+    Gaia_EDR3__pmra_error:
+      include: false
+      dtype: float
+    PS1_DR1___id:
+      include: false
+      dtype: int
+    PS1_DR1__gMeanPSFMag:
+      include: true
+      dtype: float
+    PS1_DR1__gMeanPSFMagErr:
+      include: true
+      dtype: float
+    PS1_DR1__iMeanPSFMag:
+      include: true
+      dtype: float
+    PS1_DR1__iMeanPSFMagErr:
+      include: true
+      dtype: float
+    PS1_DR1__qualityFlag:
+      include: false
+      dtype: int
+    PS1_DR1__rMeanPSFMag:
+      include: true
+      dtype: float
+    PS1_DR1__rMeanPSFMagErr:
+      include: true
+      dtype: float
+    PS1_DR1__yMeanPSFMag:
+      include: true
+      dtype: float
+    PS1_DR1__yMeanPSFMagErr:
+      include: true
+      dtype: float
+    PS1_DR1__zMeanPSFMag:
+      include: true
+      dtype: float
+    PS1_DR1__zMeanPSFMagErr:
+      include: true
+      dtype: float
 
 feature_stats:
   # d15-based

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -397,7 +397,7 @@ features:
       dtype: float
     ccd:
       include: false
-      dtype: int
+      dtype: Int64
     chi2red:
       include: true
       dtype: float
@@ -448,7 +448,7 @@ features:
       dtype: float
     field:
       include: false
-      dtype: int
+      dtype: Int64
     i60r:
       include: true
       dtype: float
@@ -481,7 +481,7 @@ features:
       dtype: float
     n_ztf_alerts:
       include: false
-      dtype: int
+      dtype: Int64
     norm_excess_var:
       include: true
       dtype: float
@@ -496,7 +496,7 @@ features:
       dtype: float
     quad:
       include: false
-      dtype: int
+      dtype: Int64
     ra:
       include: false
       dtype: float
@@ -536,7 +536,7 @@ features:
       dtype: float
     ccd:
       include: false
-      dtype: int
+      dtype: Int64
     chi2red:
       include: true
       dtype: float
@@ -587,7 +587,7 @@ features:
       dtype: float
     field:
       include: false
-      dtype: int
+      dtype: Int64
     i60r:
       include: true
       dtype: float
@@ -620,7 +620,7 @@ features:
       dtype: float
     n_ztf_alerts:
       include: true
-      dtype: int
+      dtype: Int64
     norm_excess_var:
       include: true
       dtype: float
@@ -635,7 +635,7 @@ features:
       dtype: float
     quad:
       include: false
-      dtype: int
+      dtype: Int64
     ra:
       include: false
       dtype: float
@@ -671,7 +671,7 @@ features:
       dtype: float
     AllWISE___id:
       include: false
-      dtype: int
+      dtype: Int64
     AllWISE__ph_qual:
       include: false
       dtype: str
@@ -701,7 +701,7 @@ features:
       dtype: float
     Gaia_EDR3___id:
       include: false
-      dtype: int
+      dtype: Int64
     Gaia_EDR3__astrometric_excess_noise:
       include: false
       dtype: float
@@ -737,7 +737,7 @@ features:
       dtype: float
     PS1_DR1___id:
       include: false
-      dtype: int
+      dtype: Int64
     PS1_DR1__gMeanPSFMag:
       include: true
       dtype: float
@@ -752,7 +752,7 @@ features:
       dtype: float
     PS1_DR1__qualityFlag:
       include: false
-      dtype: int
+      dtype: Int64
     PS1_DR1__rMeanPSFMag:
       include: true
       dtype: float
@@ -773,7 +773,7 @@ features:
       dtype: float
     _id:
       include: false
-      dtype: int
+      dtype: Int64
     coordinates:
       include: false
       dtype: object

--- a/scope.py
+++ b/scope.py
@@ -514,7 +514,9 @@ class Scope:
         train_config = self.config["training"]["classes"][tag]
 
         all_features = self.config["features"][train_config["features"]]
-        features = [key for key in all_features if all_features[key]["include"]]
+        features = [
+            key for key in all_features if forgiving_true(all_features[key]["include"])
+        ]
 
         ds = Dataset(
             tag=tag,
@@ -784,7 +786,9 @@ class Scope:
 
             all_feature_names = self.config["features"]["ontological"]
             feature_names = [
-                x for x in all_feature_names if all_feature_names[x]['include']
+                x
+                for x in all_feature_names
+                if forgiving_true(all_feature_names[x]['include'])
             ]
             class_names = [
                 self.config["training"]["classes"][class_name]["label"]

--- a/scope.py
+++ b/scope.py
@@ -513,7 +513,8 @@ class Scope:
 
         train_config = self.config["training"]["classes"][tag]
 
-        features = self.config["features"][train_config["features"]]
+        all_features = self.config["features"][train_config["features"]]
+        features = [key for key in all_features if all_features[key]["include"]]
 
         ds = Dataset(
             tag=tag,
@@ -781,7 +782,10 @@ class Scope:
             if not path_mock.exists():
                 path_mock.mkdir(parents=True, exist_ok=True)
 
-            feature_names = self.config["features"]["ontological"]
+            all_feature_names = self.config["features"]["ontological"]
+            feature_names = [
+                x for x in all_feature_names if all_feature_names[x]['include']
+            ]
             class_names = [
                 self.config["training"]["classes"][class_name]["label"]
                 for class_name in self.config["training"]["classes"]

--- a/scope.py
+++ b/scope.py
@@ -786,9 +786,9 @@ class Scope:
 
             all_feature_names = self.config["features"]["ontological"]
             feature_names = [
-                x
-                for x in all_feature_names
-                if forgiving_true(all_feature_names[x]['include'])
+                key
+                for key in all_feature_names
+                if forgiving_true(all_feature_names[key]['include'])
             ]
             class_names = [
                 self.config["training"]["classes"][class_name]["label"]

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -14,6 +14,7 @@ import os
 import time
 import h5py
 import pyarrow.dataset as ds
+from scope.utils import forgiving_true
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 warnings.filterwarnings('ignore')
@@ -334,7 +335,9 @@ def run(
             train_config = config["training"]["classes"][model_class]
             all_features = config["features"][train_config["features"]]
             feature_names = [
-                key for key in all_features if all_features[key]["include"]
+                key
+                for key in all_features
+                if forgiving_true(all_features[key]["include"])
             ]
             scale_features = "min_max"
 

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -332,7 +332,10 @@ def run(
             # scale features
             ts = time.time()
             train_config = config["training"]["classes"][model_class]
-            feature_names = config["features"][train_config["features"]]
+            all_features = config["features"][train_config["features"]]
+            feature_names = [
+                key for key in all_features if all_features[key]["include"]
+            ]
             scale_features = "min_max"
 
             for feature in feature_names:


### PR DESCRIPTION
This PR continues the debug/improvement process for the inference pipeline. It modifies config.defaults.yaml, restructuring the phenomenological and ontological feature lists. Each feature on the list now has a boolean `include` field (taking the place of the `#` used in the previous version). This PR would supersede #142, so features having `include = True` are the same as agreed upon in that discussion.

Each feature in the config file also has a `dtype` field to explicitly specify the datatype. An upcoming PR will make use of this field to ensure more consistency in files generated by `get_features.py`. Currently, pandas does not always infer types uniformly.

Lines in `scope.py` and `inference.py` where the config features list is used are refactored in this PR for compatibility with the new config format.