### PR TITLE
Set feature datatypes and resume interrupted downloads

### DIFF
--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -23,7 +23,7 @@ with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
 # Access datatypes in config file
 feature_names = config['features']['ontological']
-dtype_dict = {x: feature_names[x]['dtype'] for x in feature_names}
+dtype_dict = {key: feature_names[key]['dtype'] for key in feature_names}
 
 # Use new penquins KowalskiInstances class here once approved
 kowalski = Kowalski(

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -89,7 +89,7 @@ def get_features_loop(
         # Remove existing source_ids from list
         todo_source_ids = list(set(source_ids) - set(existing_ids))
         if len(todo_source_ids) == 0:
-            print('File is already complete.')
+            print('Dataset is already complete.')
             return
 
     n_sources = len(source_ids)

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -21,6 +21,9 @@ TIMEOUT = 300
 config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
 with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+# Access datatypes in config file
+feature_names = config['features']['ontological']
+dtype_dict = {x: feature_names[x]['dtype'] for x in feature_names}
 
 # Use new penquins KowalskiInstances class here once approved
 kowalski = Kowalski(
@@ -147,8 +150,8 @@ def get_features(
             print(response)
             raise ValueError(f"No data found for source ids {source_ids}")
 
-        df_temp = pd.DataFrame.from_records(source_data)
-        # Add code here to standardize dtypes from config file
+        df_temp = pd.DataFrame(source_data)
+        df_temp = df_temp.astype(dtype=dtype_dict)
         df_collection += [df_temp]
         try:
             dmdt_temp = np.expand_dims(
@@ -222,7 +225,7 @@ def run(**kwargs):
     DEFAULT_CCD = 1
     DEFAULT_QUAD = 1
     DEFAULT_LIMIT = 1000
-    DEFAULT_SAVE_BATCHSIZE = 1000
+    DEFAULT_SAVE_BATCHSIZE = 100000
     DEFAULT_CATALOG = "ZTF_source_features_DR5"
 
     field = kwargs.get("field", DEFAULT_FIELD)

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -76,11 +76,11 @@ def get_features_loop(
     DS = ds.dataset(os.path.dirname(outfile), format='parquet')
     indiv_files = DS.files
     files_exist = len(indiv_files) > 0
+    existing_ids = []
 
     # Set source_ids
     if (not restart) & (files_exist):
         generator = DS.to_batches(columns=['_id'])
-        existing_ids = []
         for batch in generator:
             existing_ids += batch['_id'].to_pylist()
         # Remove existing source_ids from list
@@ -148,6 +148,7 @@ def get_features(
             raise ValueError(f"No data found for source ids {source_ids}")
 
         df_temp = pd.DataFrame.from_records(source_data)
+        # Add code here to standardize dtypes from config file
         df_collection += [df_temp]
         try:
             dmdt_temp = np.expand_dims(
@@ -221,7 +222,7 @@ def run(**kwargs):
     DEFAULT_CCD = 1
     DEFAULT_QUAD = 1
     DEFAULT_LIMIT = 1000
-    DEFAULT_SAVE_BATCHSIZE = 100000
+    DEFAULT_SAVE_BATCHSIZE = 1000
     DEFAULT_CATALOG = "ZTF_source_features_DR5"
 
     field = kwargs.get("field", DEFAULT_FIELD)


### PR DESCRIPTION
Following up on #164, this PR modifies get_features.py to set feature datatypes based on the contents of the scope config file, ensuring consistency among each parquet file saved for the field.

This PR also updates how interrupted downloads are resumed given the use of many parquet files to comprise a field's dataset. As long as DEFAULT_SAVE_BATCHSIZE is kept constant for the field, an interrupted download can be resumed by running the same command again.