### PR TITLE
Save inference results in HDF5 format

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -773,7 +773,7 @@ features:
       dtype: float
     _id:
       include: false
-      dtype: Int64
+      dtype: int
     coordinates:
       include: false
       dtype: object

--- a/scope/__init__.py
+++ b/scope/__init__.py
@@ -5,7 +5,7 @@ from .fritz import *
 
 # Below code adapted from https://github.com/skyportal/skyportal/blob/main/skyportal/__init__.py
 # 2022-10-18
-__version__ = '0.2.dev0'
+__version__ = '0.3.dev0'
 
 if 'dev' in __version__:
     # Append last commit date and hash to dev version information, if available


### PR DESCRIPTION
This PR saves inference results in HDF5 format including relevant metadata. CSV files can optionally be saved as well.

Also, the datatype of the `_id` field is changed from pandas `Int64` to `int` to avoid an error when saving inference results. Finally, the version of the code is bumped.

Closes #160