### PR TITLE
Change flake8 repo link to fix failing tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: black
         pass_filenames: true
         exclude: .ipynb_checkpoints|data|^.fits
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8


### PR DESCRIPTION
This PR changes the link to the flake8 repo in pre-commit-config.yaml from gitlab.com to github.com. See e.g. [here](https://www.reddit.com/r/Python/comments/yvfww8/flake8_took_down_the_gitlab_repository_in_favor/) for some background on this change. The tests may continue to fail when running on this PR, but after merging will hopefully start to pass again.