### PR TITLE
Add probability threshold for classification uploads

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -154,7 +154,7 @@ inputs:
 8. Index to stop uploading (inclusive)
 9. Skip photometry upload (existing sources only)
 10. Origin of ZTF data. If set, values in ztf_id CSV column will post as annotations.
-11. Probability threshold for posted classification (values must be greater than this number to post)
+11. Probability threshold for posted classification (values must be >= than this number to post)
 
 process:
 1. get object ids of all the data from Fritz using the ra, dec, and period

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -154,6 +154,7 @@ inputs:
 8. Index to stop uploading (inclusive)
 9. Skip photometry upload (existing sources only)
 10. Origin of ZTF data. If set, values in ztf_id CSV column will post as annotations.
+11. Probability threshold for posted classification (values must be greater than this number to post)
 
 process:
 1. get object ids of all the data from Fritz using the ra, dec, and period
@@ -163,7 +164,7 @@ process:
 5. (post comment to each uploaded source)
 
 ```sh
-./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification variable flaring -taxonomy_map map.json -comment vetted -start 35 -stop 50 -skip_phot False -ztf_origin ZTF_DR5
+./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -taxonomy_id 7 -classification variable flaring -taxonomy_map map.json -comment vetted -start 35 -stop 50 -skip_phot False -ztf_origin ZTF_DR5 -p_threshold 0.9
 ```
 
 ## Scope Manage Annotation

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -84,9 +84,13 @@ def upload_classification(
 
         if read_classes:
             row_classes = row[classes]  # limit current row to specific columns
-            threshold_keys = row_classes.keys()[
-                row_classes >= p_threshold
-            ]  # determine which dataset classifications are nonzero
+            if p_threshold > 0.0:
+                threshold_keys = row_classes.keys()[
+                    row_classes >= p_threshold
+                ]  # determine which dataset classifications are nonzero
+            # Do not post classifications if p = 0
+            else:
+                threshold_keys = row_classes.keys()[row_classes > 0]
 
             for val in threshold_keys:
                 cls = tax_map[val]['fritz_label']

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -43,7 +43,7 @@ def upload_classification(
     :param stop: index in CSV file to stop upload (inclusive) (int)
     :ztf_origin: origin of uploaded ZTF data; if set, posts ztf_id to annotation (str)
     :skip_phot: if True, only upload groups and classifications (no photometry) (bool)
-    :p_threshold: classification probabilties must be > this number to post (float)
+    :p_threshold: classification probabilties must be >= this number to post (float)
     """
 
     # read in file to csv
@@ -85,7 +85,7 @@ def upload_classification(
         if read_classes:
             row_classes = row[classes]  # limit current row to specific columns
             threshold_keys = row_classes.keys()[
-                row_classes > p_threshold
+                row_classes >= p_threshold
             ]  # determine which dataset classifications are nonzero
 
             for val in threshold_keys:
@@ -284,7 +284,7 @@ if __name__ == "__main__":
         "-p_threshold",
         type=float,
         default=0.0,
-        help="Classification probability > this number to upload",
+        help="Classification probability >= this number to upload",
     )
 
     args = parser.parse_args()

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -28,6 +28,7 @@ def upload_classification(
     stop: int,
     ztf_origin: str,
     skip_phot: bool = False,
+    p_threshold: float = 0.0,
 ):
     """
     Upload labels to Fritz
@@ -42,6 +43,7 @@ def upload_classification(
     :param stop: index in CSV file to stop upload (inclusive) (int)
     :ztf_origin: origin of uploaded ZTF data; if set, posts ztf_id to annotation (str)
     :skip_phot: if True, only upload groups and classifications (no photometry) (bool)
+    :p_threshold: classification probabilties must be > this number to post (float)
     """
 
     # read in file to csv
@@ -82,11 +84,11 @@ def upload_classification(
 
         if read_classes:
             row_classes = row[classes]  # limit current row to specific columns
-            nonzero_keys = row_classes.keys()[
-                row_classes > 0
+            threshold_keys = row_classes.keys()[
+                row_classes > p_threshold
             ]  # determine which dataset classifications are nonzero
 
-            for val in nonzero_keys:
+            for val in threshold_keys:
                 cls = tax_map[val]['fritz_label']
                 tax_id = tax_map[val]['taxonomy_id']
                 if cls != 'None':  # if Fritz taxonomy value exists, add to class list
@@ -278,6 +280,13 @@ if __name__ == "__main__":
 
     parser.add_argument("-ztf_origin", type=str, help="Origin of uploaded ZTF data")
 
+    parser.add_argument(
+        "-p_threshold",
+        type=float,
+        default=0.0,
+        help="Classification probability > this number to upload",
+    )
+
     args = parser.parse_args()
 
     # upload classification objects
@@ -293,4 +302,5 @@ if __name__ == "__main__":
         args.stop,
         args.ztf_origin,
         args.skip_phot,
+        args.p_threshold,
     )


### PR DESCRIPTION
This PR adds a probability threshold argument to scope_upload_classification.py. Only classifications with a probability greater than the threshold will be uploaded. This is useful for active learning purposes and any time we want to post only a subset of potential classifications.