### PR TITLE
Convert ZTF ID to int before uploading

### DIFF
--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 MAX_ATTEMPTS = 10
 RADIUS_ARCSEC = 2
-UPLOAD_BATCHSIZE = 10
+UPLOAD_BATCHSIZE = 5
 
 
 def upload_classification(
@@ -224,7 +224,7 @@ def upload_classification(
 
         # Post ZTF ID as annotation
         if ztf_origin is not None:
-            ztfid = str(row['ztf_id'])
+            ztfid = str(int(row['ztf_id']))
             scope_manage_annotation.manage_annotation(
                 'POST', obj_id, group_ids, ztf_origin, 'ztf_id', ztfid
             )

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 MAX_ATTEMPTS = 10
 RADIUS_ARCSEC = 2
-UPLOAD_BATCHSIZE = 5
+UPLOAD_BATCHSIZE = 10
 
 
 def upload_classification(


### PR DESCRIPTION
This PR ensures that a source's ZTF ID is converted to an integer before its string representation is uploaded to Fritz.