### PR TITLE
Fix annotation bug for existing sources with no ZTF ID

### DIFF
--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -259,17 +259,22 @@ def upload_classification(
                     x['data']
                     for x in source_to_update['annotations']
                     if x['origin'] == ztf_origin
-                ][0]
-                n_existing_ztf_ids = len(existing_ztf_ids.keys())
-                if ztfid not in existing_ztf_ids.values():
+                ]
+                if len(existing_ztf_ids) == 0:
                     scope_manage_annotation.manage_annotation(
-                        'UPDATE',
-                        obj_id,
-                        group_ids,
-                        ztf_origin,
-                        f'ztf_id_{n_existing_ztf_ids+1}',
-                        str(ztfid),
+                        'POST', obj_id, group_ids, ztf_origin, 'ztf_id', str(ztfid)
                     )
+                else:
+                    n_existing_ztf_ids = len(existing_ztf_ids[0].keys())
+                    if ztfid not in existing_ztf_ids[0].values():
+                        scope_manage_annotation.manage_annotation(
+                            'UPDATE',
+                            obj_id,
+                            group_ids,
+                            ztf_origin,
+                            f'ztf_id_{n_existing_ztf_ids+1}',
+                            str(ztfid),
+                        )
 
         # batch upload classifications
         if len(dict_list) != 0:


### PR DESCRIPTION
This PR fixes a bug in scope_upload_classification.py where an error is raised during annotation posting if a source exists on Fritz but without any ZTF ID annotation. The code now handles this scenario by posting a new annotation to Fritz in the same way that it would if the source did not exist.