### PR TITLE
Reorganize and update defaults for API try/except loop

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -12,6 +12,8 @@ fritz:
   token:
   protocol: https
   host: fritz.science
+  max_attempts: 10
+  sleep_time: 5
 wandb:
   project: scope
   # Get your W&B token at https://wandb.ai/authorize

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -10,6 +10,7 @@ from requests.exceptions import InvalidJSONError, JSONDecodeError
 from urllib3.exceptions import ProtocolError
 
 MAX_ATTEMPTS = 10
+SLEEP_TIME = 5
 
 
 def get_highscoring_objects(
@@ -79,8 +80,8 @@ def api(
     data: Optional[Mapping] = None,
     token: str = fritz_token,
     base_url: str = BASE_URL,
-    max_attempts: int = 1,
-    sleep_time: int = 5,
+    max_attempts: int = MAX_ATTEMPTS,
+    sleep_time: int = SLEEP_TIME,
 ):
     method = method.upper()
     headers = {"Authorization": f"token {token}"}

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -9,9 +9,6 @@ import pandas as pd
 from requests.exceptions import InvalidJSONError, JSONDecodeError
 from urllib3.exceptions import ProtocolError
 
-MAX_ATTEMPTS = 10
-SLEEP_TIME = 5
-
 
 def get_highscoring_objects(
     G,
@@ -70,7 +67,9 @@ def get_stats(G, ids):
 config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
 with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
-BASE_URL = "https://fritz.science/"
+BASE_URL = f"{config['fritz']['protocol']}://{config['fritz']['host']}/"
+MAX_ATTEMPTS = config['fritz']['max_attempts']
+SLEEP_TIME = config['fritz']['sleep_time']
 fritz_token = config['fritz']['token']
 
 

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -11,7 +11,6 @@ import pathlib
 from tools import scope_manage_annotation
 from datetime import datetime
 
-MAX_ATTEMPTS = 10
 RADIUS_ARCSEC = 2
 UPLOAD_BATCHSIZE = 10
 


### PR DESCRIPTION
This PR reorganizes and updates the default values for the try/except loop governing Fritz API calls. The defaults of 10 attempts and 5 seconds between attempts are defined at the top of fritz.py, and one extraneous default value is removed from scope_upload_classification.py