### PR TITLE
Add method to select sources/classifications for active learning

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -846,7 +846,7 @@ class Scope:
         group: str = 'experiment',
         min_class_examples: int = 1000,
         probability_threshold: float = 0.9,
-        AL_directory: str = 'AL_datasets',
+        al_directory: str = 'AL_datasets',
         filename: str = 'active_learning_set',
         algorithm: str = 'dnn',
         exclude_training_sources: bool = False,
@@ -860,7 +860,7 @@ class Scope:
         :param group: name of group containing trained models within models directory (str)
         :param min_class_examples: minimum number of examples to include for each class. Some classes may contain fewer than this if the sample is limited (int)
         :param probability_threshold: minimum probability to select examples for active learning (float)
-        :param AL_directory: name of directory to create/populate with active learning sample (str)
+        :param al_directory: name of directory to create/populate with active learning sample (str)
         :param filename: name of file (no extension) to store active learning sample (str)
         :param algorithm: algorithm [dnn or xgb] (str)
         :param exclude_training_sources: if True, exclude sources in current training set from AL sample (bool)
@@ -991,7 +991,7 @@ class Scope:
 
         # Strip extension from filename if provided
         filename = filename.split('.')[0]
-        AL_directory_path = str(base_path / f'{AL_directory}_{algorithm}' / filename)
+        AL_directory_path = str(base_path / f'{al_directory}_{algorithm}' / filename)
         os.makedirs(AL_directory_path, exist_ok=True)
 
         # Write hdf5 and csv files

--- a/scope.py
+++ b/scope.py
@@ -840,7 +840,7 @@ class Scope:
             else:
                 raise ValueError('algorithm must be DNN or XGB')
 
-    def select_AL_sample(
+    def select_al_sample(
         self,
         fields: Union[list, str] = 'all',
         group: str = 'experiment',
@@ -869,7 +869,7 @@ class Scope:
 
         :return:
 
-        :example:  ./scope.py select_AL_sample --fields=[296, 297] --group='experiment' --min_class_examples=1000 --probability_threshold=0.9 --exclude_training_sources
+        :example:  ./scope.py select_al_sample --fields=[296, 297] --group='experiment' --min_class_examples=1000 --probability_threshold=0.9 --exclude_training_sources
         """
         base_path = pathlib.Path(__file__).parent.absolute()
         preds_path = base_path / 'preds'

--- a/scope.py
+++ b/scope.py
@@ -909,7 +909,9 @@ class Scope:
         include_nonvar = False
         if f'vnv_{algorithm}' in preds_df.columns:
             include_nonvar = True
-            preds_df[f'nonvar_{algorithm}'] = 1 - preds_df[f'vnv_{algorithm}']
+            preds_df[f'nonvar_{algorithm}'] = np.round(
+                1 - preds_df[f'vnv_{algorithm}'], 2
+            )
 
         if exclude_training_sources:
             # Get training set from config file

--- a/scope.py
+++ b/scope.py
@@ -950,6 +950,9 @@ class Scope:
         preds_df.set_index('_id', inplace=True)
         toPost_df.set_index('_id', inplace=True)
 
+        # Fix random state to allow reproducible results
+        rng = np.random.RandomState(9)
+
         for tag in model_tags:
             # Idenfity all sources above probability threshold
             highprob_preds = preds_df[
@@ -967,7 +970,7 @@ class Scope:
             if still_to_post_count > 0:
                 if len(highprob_preds) >= still_to_post_count:
                     # Randomly select from remaining examples without replacement
-                    highprob_toPost = np.random.choice(
+                    highprob_toPost = rng.choice(
                         highprob_preds.drop(existing_df.index).index,
                         still_to_post_count,
                         replace=False,


### PR DESCRIPTION
This PR adds a `select_al_sample` method to `scope.py` to select sources and their classifications from a collection of predictions and make an active learning sample. The method optionally removes sources in the current training set before selecting at random a user-specified minimum number of sources having classifications with probabilities ≥ a given probability threshold. The output is a dataset that can be posted to Fritz using `scope_upload_classification.py`. 

One additional feature to consider is a fixed random state to allow reproducible active learning samples to be made from the same collection of predictions.