### PR TITLE
Fix callbacks for pre-trained model, use legacy optimizer

### DIFF
--- a/.requirements/dev.txt
+++ b/.requirements/dev.txt
@@ -2,10 +2,10 @@ deepdiff>=5.0
 gsutil>=4.60
 keras-tuner>=1.0.2
 matplotlib>=3.3
-numpy<1.20
+numpy
 pytest>=6.1.2
 questionary>=1.8.1
 scikit-learn>=0.24.1
-tensorflow<2.6
+tensorflow
 tensorflow-addons>=0.12
 wandb>=0.12.1

--- a/scope.py
+++ b/scope.py
@@ -650,7 +650,6 @@ class Scope:
                 },
             )
             classifier.meta["callbacks"].append(WandbCallback())
-            print('callback', classifier.meta['callbacks'])
 
         classifier.train(
             datasets["train"],

--- a/scope.py
+++ b/scope.py
@@ -603,6 +603,7 @@ class Scope:
                     training_set_inputs[inpt_name].shape
                 )
             print('Input shapes are consistent.')
+            classifier.set_callbacks(callbacks, tag, **kwargs)
 
         else:
             classifier.setup(
@@ -649,6 +650,7 @@ class Scope:
                 },
             )
             classifier.meta["callbacks"].append(WandbCallback())
+            print('callback', classifier.meta['callbacks'])
 
         classifier.train(
             datasets["train"],


### PR DESCRIPTION
This PR fixes an error that was raised when running additional training on pre-trained models. The callbacks metadata for the pre-trained model is not saved and so cannot be loaded in like the rest of the model components. Thus, there is now a separate `set_callbacks` method in `nn.py` which is called when loading in a pre-trained model. 

Additionally, this PR adds compatibility with the latest `tensorflow-macos` (2.11), which raises an error when accessing `tf.keras.optimizers.Adam`. The replacement, `tf.keras.optimizers.legacy.Adam`, is also included in the previous `tensorflow-macos` version (2.10), so this change will not break scope on environments set up in September 2022 and onward.

(On the topic of tensorflow versions and M1 Macs, see also the updates in #125 pertaining to GPU support.)