### PR TITLE
Handle missing photometry during source upload

### DIFF
--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -273,24 +273,27 @@ def save_newsource(
 
     # generate position-based name if obj_id not set
     if obj_id is None:
-        ra_mean = float(
-            np.mean(
-                [
-                    light_curve["ra"]
-                    for light_curve in light_curves
-                    if light_curve.get("ra") is not None
-                ]
+        if light_curves is not None:
+            ra_mean = float(
+                np.mean(
+                    [
+                        light_curve["ra"]
+                        for light_curve in light_curves
+                        if light_curve.get("ra") is not None
+                    ]
+                )
             )
-        )
-        dec_mean = float(
-            np.mean(
-                [
-                    light_curve["dec"]
-                    for light_curve in light_curves
-                    if light_curve.get("dec") is not None
-                ]
+            dec_mean = float(
+                np.mean(
+                    [
+                        light_curve["dec"]
+                        for light_curve in light_curves
+                        if light_curve.get("dec") is not None
+                    ]
+                )
             )
-        )
+        else:
+            ra_mean, dec_mean = ra, dec
         obj_id = radec_to_iau_name(ra_mean, dec_mean, prefix="ZTFJ")
 
         # post new source to Fritz

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -331,7 +331,7 @@ def save_newsource(
         "dec": df_photometry["dec"].tolist(),
         "group_ids": group_ids,
     }
-    print(len(photometry.get("mag", ())))
+
     if len(photometry.get("mag", ())) == 0:
         print('No unflagged photometry available. Skipping source.')
         return None

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -63,16 +63,15 @@ def upload_classification(
 
     # read in file to csv
     if file.endswith('.csv'):
-        sources = pd.read_csv(file)
+        all_sources = pd.read_csv(file)
     elif file.endswith('.h5'):
-        sources = read_hdf(file)
-        print(sources)
+        all_sources = read_hdf(file)
     elif file.endswith('.parquet'):
-        sources = read_parquet(file)
+        all_sources = read_parquet(file)
     else:
         raise TypeError('Input file must be csv, h5 or parquet format.')
-    columns = sources.columns
-    all_sources = sources.copy()
+    columns = all_sources.columns
+    sources = all_sources.copy()
 
     if start is not None:
         sources = sources.loc[start:]
@@ -420,11 +419,12 @@ def upload_classification(
 
                 if 'obj_id' not in all_sources.columns:
                     all_sources['obj_id'] = ''
-                all_sources['obj_id'].loc[start:stop] = sources_to_write['obj_id']
+                all_sources.loc[start:stop, 'obj_id'] = sources_to_write['obj_id']
 
                 print(
                     'Saving obj_id for uploaded sources. If upload is incomplete, use this file for future uploads to continue filling the obj_id column.'
                 )
+                print()
                 if result_format == '.csv':
                     all_sources.to_csv(filepath, index=False)
                 elif result_format == '.h5':


### PR DESCRIPTION
This PR reorganizes source uploads to skip sources without photometry. If a list of uploaded sources is requested, sources without photometry will have an empty field in the obj_id column to indicate that they were not uploaded.