### PR TITLE
Add more flexibility to get_features.py

### DIFF
--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -224,6 +224,10 @@ def run(**kwargs):
         if True, write results and make necessary directories.
     write_csv: bool
         if True, writes results as csv file in addition to parquet.
+    column_list: list
+        List of strings for each column to return from Kowalski colleciton.
+    suffix: str
+        Suffix to add to saved feature file.
     Returns
     =======
     Stores the features in a file at the following location:

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -48,7 +48,7 @@ def get_features_loop(
     max_sources: int = 100000,
     restart: bool = True,
     write_csv: bool = False,
-    column_list: list = [],
+    projection: list = [],
     suffix: str = None,
 ):
     '''
@@ -111,7 +111,7 @@ def get_features_loop(
             features_catalog=features_catalog,
             verbose=verbose,
             limit_per_query=limit_per_query,
-            column_list=column_list,
+            projection=projection,
         )
 
         write_parquet(df, f'{outfile}_iter_{i}.parquet')
@@ -125,7 +125,7 @@ def get_features(
     features_catalog: str = "ZTF_source_features_DR5",
     verbose: bool = False,
     limit_per_query: int = 1000,
-    column_list: list = [],
+    projection: list = [],
 ):
     '''
     Get features of all ids present in the field in one file.
@@ -148,7 +148,7 @@ def get_features(
                         ]
                     }
                 },
-                "projection": column_list,
+                "projection": projection,
             },
         }
         response = kowalski.query(query=query)
@@ -159,7 +159,7 @@ def get_features(
             raise ValueError(f"No data found for source ids {source_ids}")
 
         df_temp = pd.DataFrame(source_data)
-        if column_list == []:
+        if projection == []:
             df_temp = df_temp.astype(dtype=dtype_dict)
         df_collection += [df_temp]
         try:
@@ -167,7 +167,7 @@ def get_features(
                 np.array([d for d in df_temp['dmdt'].values]), axis=-1
             )
         except Exception as e:
-            if "dmdt" in column_list:
+            if "dmdt" in projection:
                 print("Error", e)
                 print(df_temp)
         dmdt_collection += [dmdt_temp]
@@ -255,7 +255,7 @@ def run(**kwargs):
 
     if column_list != []:
         keys = [name for name in column_list]
-        column_list = {k: 1 for k in keys}
+        projection = {k: 1 for k in keys}
 
     if not whole_field:
         default_file = (
@@ -300,7 +300,7 @@ def run(**kwargs):
             features_catalog=features_catalog,
             verbose=verbose,
             limit_per_query=limit_per_query,
-            column_list=column_list,
+            projection=projection,
         )
 
     else:
@@ -317,7 +317,7 @@ def run(**kwargs):
             max_sources=max_sources,
             restart=restart,
             write_csv=write_csv,
-            column_list=column_list,
+            projection=projection,
             suffix=suffix,
         )
 

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -167,7 +167,8 @@ def get_features(
                 np.array([d for d in df_temp['dmdt'].values]), axis=-1
             )
         except Exception as e:
-            if "dmdt" in projection:
+            # Print dmdt error if using the default projection or user requests the feature
+            if (projection == []) | ("dmdt" in projection):
                 print("Error", e)
                 print(df_temp)
         dmdt_collection += [dmdt_temp]

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -206,14 +206,18 @@ def run(**kwargs):
     ==========
     field: int
         Field number.
-    limit_per_query: int
-        Number of sources to query at a time.
-    whole_field: bool
-        If True, get features of all sources in the field, else get features of a particular quad.
     ccd: int
         CCD number (required if whole_field is False).
     quad: int
         Quad number (required if whole_field is False).
+    limit_per_query: int
+        Number of sources to query at a time.
+    max_sources: int
+        Number of sources to save in single file.
+    features_catalog: str
+        Name of Kowalski collection to query for features
+    whole_field: bool
+        If True, get features of all sources in the field, else get features of a particular quad.
     start: int
         Start index of the sources to query. (to be used with whole_field)
     end: int


### PR DESCRIPTION
This PR updates `get_features.py` to allow more flexibility when retrieving features. The user can now specify a projection for a Kowalski query that restricts the columns returned. When `get_features.py` is called from the command line, this projection is generated from the `column_list` argument, which contains the list of features desired by the user. Furthermore, the new `features_catalog` argument allows the user to specify which catalog to query without editing the code.

The motivation for this change is the lack of ZTF filter ids in the current Scope feature collection (`ZTF_source_features_DR5`). This information may be relevant for upcoming training, so it is important to have a quick way to query a different catalog (`ZTF_sources_20210401`) for a single column (`filter`).