### PR TITLE
Download all available feature sets

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -159,6 +159,7 @@ inputs:
 8. Name of directory to save downloaded files
 9. Name of file containing merged classifications and features
 10. Output format of saved files, if not specified in (9). Must be one of parquet, h5, or csv.
+11. Flag to add ZTF filter IDs (separate catalog query) to default features
 
 process:
 1. if CSV file provided, query by object ids or ra, dec
@@ -172,7 +173,7 @@ process:
 output: data with new columns appended.
 
 ```sh
-./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000 -taxonomy_map golden_dataset_mapper.json -output_dir fritzDownload -output_filename merged_classifications_features -output_format parquet
+./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000 -taxonomy_map golden_dataset_mapper.json -output_dir fritzDownload -output_filename merged_classifications_features -output_format parquet -get_ztf_filters
 ```
 
 ## Scope Upload Classification

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -48,7 +48,7 @@ def get_features_loop(
     max_sources: int = 100000,
     restart: bool = True,
     write_csv: bool = False,
-    projection: list = [],
+    projection: dict = {},
     suffix: str = None,
 ):
     '''
@@ -125,7 +125,7 @@ def get_features(
     features_catalog: str = "ZTF_source_features_DR5",
     verbose: bool = False,
     limit_per_query: int = 1000,
-    projection: list = [],
+    projection: dict = {},
 ):
     '''
     Get features of all ids present in the field in one file.
@@ -159,7 +159,7 @@ def get_features(
             raise ValueError(f"No data found for source ids {source_ids}")
 
         df_temp = pd.DataFrame(source_data)
-        if projection == []:
+        if projection == {}:
             df_temp = df_temp.astype(dtype=dtype_dict)
         df_collection += [df_temp]
         try:
@@ -168,7 +168,7 @@ def get_features(
             )
         except Exception as e:
             # Print dmdt error if using the default projection or user requests the feature
-            if (projection == []) | ("dmdt" in projection):
+            if (projection == {}) | ("dmdt" in projection):
                 print("Error", e)
                 print(df_temp)
         dmdt_collection += [dmdt_temp]


### PR DESCRIPTION
This PR primarily reworks `scope_download_classification.py` to download all available sets of features for each source on Fritz. Since multiple ZTF ids can be associated with a single source (corresponding to different light curve bands/fields), the one-to-one ZTF ID matching previously performed in this code has been removed. The new code uses the coordinate-based object ids from Fritz to connect labels and features.

A cone search finds all available feature sets within 2 arcsec (default) of the input coordinates for each Fritz source. In cases where multiple sources 'claim' a feature set, the source having the smallest Euclidean distance from the feature coordinates is assigned the set.

The ZTF filter ID for each feature set, which is currently located in a separate catalog, can be joined to the other features by setting the `-get_ztf_filters` flag.