### PR TITLE
Additional check on existing sources' group membership

### DIFF
--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -199,8 +199,21 @@ def upload_classification(
                     for t in create_time_list:
                         src_id = create_time_dict[t]
                         if src_id[:4] == 'ZTFJ':
-                            existing_source = src_dict[src_id]
-                            obj_id = src_id
+                            # Treat source as new if not posted to all user-specified groups
+                            posted_groups = [
+                                x['id'] for x in src_dict[src_id]['groups']
+                            ]
+                            n_missing_groups = 0
+                            for gid in group_ids:
+                                if gid not in posted_groups:
+                                    n_missing_groups += 1
+                            if n_missing_groups == 0:
+                                existing_source = src_dict[src_id]
+                                obj_id = src_id
+                            else:
+                                print(
+                                    'Source exists but is not posted to all specified groups. Treating as a new source.'
+                                )
                             break
 
         print(f"object {index} id:", obj_id)


### PR DESCRIPTION
Some sources on Fritz have IDs that use the same ZTFJ... format we use for Scope's position-based identifiers, but they are posted to other groups for separate purposes. When using the `-skip_phot` flag (e.g. to update classifications without posting new photometry), these sources are quietly added to our specific groups, even if they lack any unflagged ZTF photometry points.

This PR adds an additional check on these sources to avoid the above scenario. If an existing source is not posted to all of the groups specified by the user in their call to `scope_upload_classificiation.py`, the code will treat the object as a new source and pass it through the necessary photometry checks.