### PR TITLE
Get ZTF filters when starting with Fritz downloaded file

### DIFF
--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -602,6 +602,7 @@ def download_classification(
                 output_dir,
                 output_filename,
                 output_format,
+                get_ztf_filters,
             )
             return merged_sources
 


### PR DESCRIPTION
This PR passes the `get_ztf_filters` flag to the feature download code in `scope_download_classification.py` when the script's arguments include an input file from Fritz. The flag was previously missing from the function call.