### PR TITLE
Add option to delete existing classifications during upload

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -197,6 +197,7 @@ inputs:
 16. Set -result_dir to customize the directory where the upload results file is saved. Default is 'fritzUpload' within the tools directory.
 17. Set -result_filetag to customize the tag appended to the result filename. Default is 'fritzUpload'.
 18. Set -result_format to one of csv, h5 or parquet to customize the result file format. Default is parquet.
+19. Set -replpace_classifications to delete each source's existing classifications before posting new ones.
 
 process:
 1. check if each input source exists by comparing input and existing ZTF IDs

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -197,7 +197,7 @@ inputs:
 16. Set -result_dir to customize the directory where the upload results file is saved. Default is 'fritzUpload' within the tools directory.
 17. Set -result_filetag to customize the tag appended to the result filename. Default is 'fritzUpload'.
 18. Set -result_format to one of csv, h5 or parquet to customize the result file format. Default is parquet.
-19. Set -replpace_classifications to delete each source's existing classifications before posting new ones.
+19. Set -replace_classifications to delete each source's existing classifications before posting new ones.
 
 process:
 1. check if each input source exists by comparing input and existing ZTF IDs

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -39,6 +39,7 @@ def upload_classification(
     result_dir: str = 'fritzUpload',
     result_filetag: str = 'fritzUpload',
     result_format: str = 'parquet',
+    replace_classifications: bool = False,
 ):
     """
     Upload labels to Fritz
@@ -61,6 +62,7 @@ def upload_classification(
     :result_dir: directory to write results from upload (str)
     :result_filetag: tag to append to input filename after upload (str)
     :result_format: format of resulting uploaded file (str)
+    :replace_classifications: if True, delete each object's existing classifications before posting new ones (bool)
     """
 
     # read in file to csv
@@ -272,6 +274,9 @@ def upload_classification(
                 class_group_dict[key] = unique_grp_ids.tolist()
 
             existing_classes = [k for k in class_group_dict.keys()]
+            if (len(existing_classes) > 0) & (replace_classifications):
+                api('DELETE', f'/api/sources/{obj_id}/classifications')
+                existing_classes = []
 
             # allow classification assignment to be skipped
             if classification is not None:
@@ -554,6 +559,13 @@ if __name__ == "__main__":
         help="Format of result file: parquet, h5 or csv",
     )
 
+    parser.add_argument(
+        "-replace_classifications",
+        action='store_true',
+        default=False,
+        help="If set, delete each object's existing classifications before posting new ones.",
+    )
+
     args = parser.parse_args()
 
     # upload classification objects
@@ -577,4 +589,5 @@ if __name__ == "__main__":
         args.result_dir,
         args.result_filetag,
         args.result_format,
+        args.replace_classifications,
     )


### PR DESCRIPTION
This PR allows the user to delete/replace each source's existing classifications when uploading new classifications. This will be useful for active learning purposes as we replace outdated classifications from a previous round of training.