### PR TITLE
Inference updates

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -859,6 +859,7 @@ class Scope:
         filename: str = 'get_all_preds_dnn.sh',
         group_name: str = 'experiment',
         algorithm: str = 'dnn',
+        scale_features: str = 'min_max',
         write_csv: bool = False,
     ):
         """
@@ -867,6 +868,7 @@ class Scope:
         :param filename: filename of shell script (must not currently exist) (str)
         :param group_name: name of group containing trained models within models directory (str)
         :param algorithm: algorithm to use in script (str)
+        :param scale_features: method to scale features (str, currently "min_max" or "median_std")
         :param write_csv: if True, write CSV file in addition to HDF5 (bool)
 
         :return:
@@ -901,7 +903,7 @@ class Scope:
                         [file for file in tag_file_gen], key=os.path.getctime
                     ).name
                     script.write(
-                        f'echo -n "{tag} ..." && python tools/inference.py --path-model=models/{group_name}/{tag}/{most_recent_file} --model-class={tag} --field=$1 --whole-field --flag_ids {addtl_args} && echo "done"\n'
+                        f'echo -n "{tag} ..." && python tools/inference.py --path-model=models/{group_name}/{tag}/{most_recent_file} --model-class={tag} --field=$1 --whole-field --flag_ids --scale_features={scale_features} {addtl_args} && echo "done"\n'
                     )
 
             elif algorithm in ['xgb', 'XGB', 'xgboost', 'XGBOOST', 'XGBoost']:

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -133,7 +133,7 @@ def clean_data(
                 missing_dict[id.astype(str)] += [feature]  # add feature to dict
 
     # impute missing values as specified in config
-    features_df = impute_features(features_df)
+    features_df = impute_features(features_df, self_impute=True)
 
     if flag_ids:
         os.makedirs(os.path.dirname(filename), exist_ok=True)

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -15,7 +15,13 @@ import time
 import h5py
 import pyarrow.dataset as ds
 import scope
-from scope.utils import read_hdf, write_hdf, forgiving_true, impute_features
+from scope.utils import (
+    read_hdf,
+    write_hdf,
+    forgiving_true,
+    impute_features,
+    get_feature_stats,
+)
 from datetime import datetime
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
@@ -59,7 +65,6 @@ def make_missing_dict(source_ids):
 def clean_data(
     features_df,
     feature_names,
-    feature_stats,
     field,
     ccd,
     quad,
@@ -74,8 +79,6 @@ def clean_data(
         dataframe containing features of all sources (output of get_features)
     feature_names : List<str>
         features of interest for inference
-    feature_stats : dict
-        feature statistics from config.yaml
     flag_ids : bool
         whether to store flagged ids and features with missing values
     ccd : int
@@ -115,8 +118,9 @@ def clean_data(
                     missing_dict[id.astype(str)] = []
                 missing_dict[id.astype(str)] += [feature]  # add feature to dict
 
-        # impute missing values as specified in config
-        features_df = impute_features(features_df)
+    # impute missing values as specified in config
+    features_df = impute_features(features_df)
+
     if flag_ids:
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         with open(filename, "w") as outfile:
@@ -246,6 +250,8 @@ def run(
     whole_field = kwargs.get("whole_field", False)
     write_csv = kwargs.get("write_csv", False)
     float_convert_types = kwargs.get("float_convert_types", (64, 32))
+    feature_stats = kwargs.get("feature_stats", None)
+    scale_features = kwargs.get("scale_features", "min_max")
 
     # default file location for source ids
     if whole_field:
@@ -309,8 +315,6 @@ def run(
             + " s"
         )
 
-    # get raw features
-    feature_stats = config.get("feature_stats", None)
     preds_collection = []
     ra_collection = np.array([])
     dec_collection = np.array([])
@@ -353,8 +357,9 @@ def run(
                 np.array([d for d in features['dmdt'].apply(list).values]), axis=-1
             )
 
-            # scale features
-            ts = time.time()
+            if verbose:
+                print("Features:\n", features)
+
             train_config = config["training"]["classes"][model_class]
             all_features = config["features"][train_config["features"]]
             feature_names = [
@@ -362,7 +367,30 @@ def run(
                 for key in all_features
                 if forgiving_true(all_features[key]["include"])
             ]
-            scale_features = "min_max"
+
+            # Impute missing data and flag source ids containing missing values
+            make_missing_dict(source_ids)
+            features = clean_data(
+                features,
+                feature_names,
+                field,
+                ccd,
+                quad,
+                flag_ids,
+                whole_field,
+            )
+
+            # Get feature stats
+            if feature_stats is None:
+                feature_stats = get_feature_stats(features, feature_names)
+            elif feature_stats == 'config':
+                feature_stats = config.get("feature_stats", None)
+
+            if verbose:
+                print("Computed feature stats:\n", feature_stats)
+
+            # scale features
+            ts = time.time()
 
             for feature in feature_names:
                 stats = feature_stats.get(feature)
@@ -375,6 +403,10 @@ def run(
                         features[feature] = (features[feature] - stats["min"]) / (
                             stats["max"] - stats["min"]
                         )
+                    else:
+                        raise ValueError(
+                            'Currently supported scaling methods are min_max and median_std.'
+                        )
             te = time.time()
             if tm:
                 print(
@@ -383,22 +415,6 @@ def run(
                     + str(round(te - ts, 4))
                     + " s"
                 )
-
-            if verbose:
-                print(features)
-
-            # Impute missing data and flag source ids containing missing values
-            make_missing_dict(source_ids)
-            features = clean_data(
-                features,
-                feature_names,
-                feature_stats,
-                field,
-                ccd,
-                quad,
-                flag_ids,
-                whole_field,
-            )  # 1
 
             ts = time.time()
             # Convert float64 to float32 to satisfy tensorflow requirements
@@ -438,7 +454,6 @@ def run(
             features = clean_data(
                 features,
                 feature_names,
-                feature_stats,
                 field,
                 ccd,
                 quad,


### PR DESCRIPTION
This PR updates the inference pipeline as follows:
- Features are self-imputed based on each batch of sources (see #233).
- The sequence of imputation -> feature stats -> scaling is now the same as the training process.
- Feature stats are by default generated with the new function in `utils.py` (see #232). The stats are generated from the training set to ensure scaling consistency between training and inference.
- The `create_inference_script` method has a new argument allowing the user to specify the feature scaling method.