### PR TITLE
Add feature imputation to downloads and fix filter bug

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -160,6 +160,7 @@ inputs:
 9. Name of file containing merged classifications and features
 10. Output format of saved files, if not specified in (9). Must be one of parquet, h5, or csv.
 11. Flag to add ZTF filter IDs (separate catalog query) to default features
+12. Flag to impute missing features using scope.utils.impute_features
 
 process:
 1. if CSV file provided, query by object ids or ra, dec
@@ -173,7 +174,7 @@ process:
 output: data with new columns appended.
 
 ```sh
-./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000 -taxonomy_map golden_dataset_mapper.json -output_dir fritzDownload -output_filename merged_classifications_features -output_format parquet -get_ztf_filters
+./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000 -taxonomy_map golden_dataset_mapper.json -output_dir fritzDownload -output_filename merged_classifications_features -output_format parquet -get_ztf_filters -impute_missing_features
 ```
 
 ## Scope Upload Classification


### PR DESCRIPTION
This PR adds the option to impute missing features in `scope_download_classification.py`. It also fixes a bug that was assigning the wrong ZTF filter IDs to downloaded sources. This bug has not affected current active learning efforts.