### PR TITLE
Rename galaxy to extended in golden dataset mapper

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1442,8 +1442,8 @@ training:
       balance: 1
       weight_per_class: false
       batch_size: 8
-    gal:
-      label: galaxy
+    ext:
+      label: extended
       features: phenomenological
       threshold: 0.7
       balance: 2.5
@@ -1619,6 +1619,7 @@ training:
       threshold: 0.7
       balance: 2.5
       weight_per_class: true
+      batch_size: 2
     rscvn:
       label: RS CVn
       features: ontological
@@ -1651,10 +1652,10 @@ training:
       threshold: 0.7
       balance: 2.5
       weight_per_class: true
+      batch_size: 2
     yso:
       label: YSO
       features: ontological
       threshold: 0.7
       balance: 3
       weight_per_class: false
-      batch_size: 8

--- a/tools/golden_dataset_mapper.json
+++ b/tools/golden_dataset_mapper.json
@@ -64,9 +64,9 @@
       "taxonomy_id": 1012
     },
 
-"galaxy":
-    {"fritz_label": "galaxy",
-      "taxonomy_id": 1012
+"extended":
+    {"fritz_label": "extended",
+      "taxonomy_id": 1017
     },
 
 "eclipsing":


### PR DESCRIPTION
All training sources on Fritz having the `galaxy` label now also have the `extended` label from the latest SCoPe Phenomenological Taxonomy. Thus, this PR renames `galaxy` to `extended` in both the golden dataset label mapper and the default config file. In the config file, two other classes with few positive examples also have a new `batch_size` argument in their hyperparameter info.