### PR TITLE
Skip Kowalski filtering by n points if minobs is zero

### DIFF
--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -258,20 +258,19 @@ def get_field_ids(
     if limit == 0:
         limit = 10000000000
 
-    fltr = {
+    filter = {
         "field": {"$eq": field},
         "ccd": {"$eq": ccd},
         "quad": {"$eq": quad},
     }
     if minobs > 0:
-        fltr["n"] = {"$gt": minobs}
+        filter["n"] = {"$gt": minobs}
 
-    print(fltr)
     q = {
         'query_type': 'find',
         'query': {
             'catalog': catalog,
-            'filter': fltr,
+            'filter': filter,
             "projection": {
                 "_id": 1,
             },

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -258,16 +258,20 @@ def get_field_ids(
     if limit == 0:
         limit = 10000000000
 
+    fltr = {
+        "field": {"$eq": field},
+        "ccd": {"$eq": ccd},
+        "quad": {"$eq": quad},
+    }
+    if minobs > 0:
+        fltr["n"] = {"$gt": minobs}
+
+    print(fltr)
     q = {
         'query_type': 'find',
         'query': {
             'catalog': catalog,
-            'filter': {
-                "field": {"$eq": field},
-                "ccd": {"$eq": ccd},
-                "quad": {"$eq": quad},
-                "n": {"$gt": minobs},
-            },
+            'filter': fltr,
             "projection": {
                 "_id": 1,
             },


### PR DESCRIPTION
This PR allows the `get_field_ids` function within `get_quad_ids.py` to return ids for `ZTF_sources_...` catalogs, which do not contain the `n` entry created during feature generation. The `{"n" : {"$gt": minobs}}` filter parameter is now only included if `minobs` is nonzero. `get_field_ids` can now be used at the start of the feature generation process in addition to the inference process.