### PR TITLE
Add Kowalski timeout to config, update collections

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -6,8 +6,11 @@ kowalski:
   timeout: 300
   collections:
     gaia: Gaia_EDR3
+    # Current sources are from DR15 (on melman)
     sources: ZTF_sources_20230109
+    # Current features generated from DR5 (on gloria)
     features: ZTF_source_features_DR5
+    # Current classifications are from DR5 (on gloria)
     classifications: ZTF_source_classifications_DR5
 fritz:
   token:

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -3,10 +3,11 @@ kowalski:
   port: 443
   protocol: https
   token:
+  timeout: 300
   collections:
     gaia: Gaia_EDR3
-    sources: ZTF_sources_20210401
-    features: ZTF_source_features_20210401
+    sources: ZTF_sources_20230109
+    features: ZTF_source_features_DR5
     classifications: ZTF_source_classifications_DR5
 fritz:
   token:


### PR DESCRIPTION
This PR adds a Kowalski timeout to the config file and updates source/feature collections to the most recent available versions.