### PR TITLE
Get ZTF alert stats

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -3,6 +3,7 @@ kowalski:
   port: 443
   protocol: https
   token:
+  alt_token:
   timeout: 300
   collections:
     gaia: Gaia_EDR3
@@ -12,6 +13,8 @@ kowalski:
     features: ZTF_source_features_DR5
     # Current classifications are from DR5 (on gloria)
     classifications: ZTF_source_classifications_DR5
+    # Current alerts (on kowalski)
+    alerts: ZTF_alerts
 fritz:
   token:
   protocol: https

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -3,6 +3,8 @@ kowalski:
   port: 443
   protocol: https
   token:
+  # For users who have more than one token for Kowalski
+  # instances, use the field below for the second token
   alt_token:
   timeout: 300
   collections:

--- a/tools/featureGeneration/alertstats.py
+++ b/tools/featureGeneration/alertstats.py
@@ -1,8 +1,13 @@
 import numpy as np
+from penquins import Kowalski
 
 
 def get_ztf_alert_stats(
-    id_dct, kowalski_instance, catalog='ZTF_alerts', radius_arcsec=2.0, limit=10000
+    id_dct: dict,
+    kowalski_instance: Kowalski,
+    catalog: str = 'ZTF_alerts',
+    radius_arcsec: float = 2.0,
+    limit: int = 10000,
 ):
     """
     Get n_ztf_alerts and mean_ztf_alert_braai features

--- a/tools/featureGeneration/alertstats.py
+++ b/tools/featureGeneration/alertstats.py
@@ -1,0 +1,78 @@
+import numpy as np
+
+
+def get_ztf_alert_stats(
+    id_dct, kowalski_instance, catalog='ZTF_alerts', radius_arcsec=2.0, limit=10000
+):
+    """
+    Get n_ztf_alerts and mean_ztf_alert_braai features
+
+    :param id_dct: one quadrant's worth of id-coordinate pairs (dict)
+    :param kowalski_instance: authenticated instance of a Kowalski database
+    :param catalog: name of alert catalog to use (str)
+    :param radius_arcsec: size of cone within which to query alerts (float)
+    :param limit: batch size of kowalski_instance queries (int)
+
+    :return alert_stats_dct: Dictionary containing n_ztf_alerts and mean_ztf_alert_braai for each source ID
+    """
+
+    ids = [x for x in id_dct]
+
+    n_sources = len(id_dct)
+    n_iterations = n_sources // limit + 1
+    alert_results_dct = {}
+
+    print(f'Querying {catalog} catalog in batches...')
+    for i in range(0, n_iterations):
+        print(f"Iteration {i+1} of {n_iterations}...")
+        id_slice = [x for x in id_dct.keys()][
+            i * limit : min(n_sources, (i + 1) * limit)
+        ]
+
+        radec_geojson = np.array(
+            [id_dct[x]['radec_geojson']['coordinates'] for x in id_slice]
+        ).transpose()
+
+        # Need to add 180 -> no negative RAs
+        radec_geojson[0, :] += 180.0
+
+        # Get ZTF alert data
+        query = {
+            "query_type": "cone_search",
+            "query": {
+                "object_coordinates": {
+                    "radec": dict(zip(id_slice, radec_geojson.transpose().tolist())),
+                    "cone_search_radius": radius_arcsec,
+                    "cone_search_unit": 'arcsec',
+                },
+                "catalogs": {
+                    catalog: {"filter": {}, "projection": {"classifications.braai": 1}}
+                },
+                "filter": {},
+            },
+        }
+        q = kowalski_instance.query(query)
+
+        alert_results = q['data'][catalog]
+        alert_results_dct.update(alert_results)
+
+    alert_stats_dct = {}
+
+    for id in ids:
+        n_ztf_alerts = len(q['data']['ZTF_alerts'][str(id)])
+        if n_ztf_alerts > 0:
+            mean_ztf_alert_braai = np.nanmean(
+                [
+                    y
+                    for x in q['data']['ZTF_alerts'][str(id)]
+                    for y in x['classifications'].values()
+                ]
+            )
+        else:
+            mean_ztf_alert_braai = 0.0
+        alert_stats_dct[id] = {
+            'n_ztf_alerts': n_ztf_alerts,
+            'mean_ztf_alert_braai': mean_ztf_alert_braai,
+        }
+
+    return alert_stats_dct

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -61,12 +61,12 @@ kowalski_instances = {'kowalski': kowalski, 'gloria': gloria, 'melman': melman}
 
 
 def drop_close_bright_stars(
-    id_dct,
-    kowalski_instance,
-    catalog=gaia_catalog,
-    query_radius_arcsec=300.0,
-    xmatch_radius_arcsec=2.0,
-    limit=10000,
+    id_dct: dict,
+    kowalski_instance: Kowalski,
+    catalog: str = gaia_catalog,
+    query_radius_arcsec: float = 300.0,
+    xmatch_radius_arcsec: float = 2.0,
+    limit: int = 10000,
 ):
     """
     Use Gaia to identify and drop sources that are too close to bright stars
@@ -209,21 +209,21 @@ def drop_close_bright_stars(
 # xmatch_radius_arcsec=2., kowalski_instances = kowalski_instances, limit=10000, doAllFields=False, field=296, doAllCCDs=False,
 # ccd=1, doAllQuads=False, quad=1, min_n_lc_points=50, min_cadence_minutes=30., dirname='generated_features', filename='features', doNotSave=False):
 def generate_features(
-    source_catalog=source_catalog,
-    alerts_catalog=alerts_catalog,
-    gaia_catalog=gaia_catalog,
-    bright_star_query_radius_arcsec=300.0,
-    xmatch_radius_arcsec=2.0,
-    kowalski_instances=kowalski_instances,
-    limit=10000,
-    field=296,
-    ccd=1,
-    quad=1,
-    min_n_lc_points=50,
-    min_cadence_minutes=30.0,
-    dirname='generated_features',
-    filename='features',
-    doNotSave=False,
+    source_catalog: str = source_catalog,
+    alerts_catalog: str = alerts_catalog,
+    gaia_catalog: str = gaia_catalog,
+    bright_star_query_radius_arcsec: float = 300.0,
+    xmatch_radius_arcsec: float = 2.0,
+    kowalski_instances: dict = kowalski_instances,
+    limit: int = 10000,
+    field: int = 296,
+    ccd: int = 1,
+    quad: int = 1,
+    min_n_lc_points: int = 50,
+    min_cadence_minutes: float = 30.0,
+    dirname: str = 'generated_features',
+    filename: str = 'features',
+    doNotSave: bool = False,
 ):
 
     # Get code version and current date/time for metadata

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -18,6 +18,7 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from datetime import datetime
+from tools.featureGeneration import alertstats
 
 # import time
 # from tools.featureGeneration import lcstats, periodsearch
@@ -44,11 +45,19 @@ melman = Kowalski(
     port=443,
     timeout=timeout,
 )
+kowalski = Kowalski(
+    token=config['kowalski']['alt_token'],
+    protocol="https",
+    host="kowalski.caltech.edu",
+    port=443,
+    timeout=timeout,
+)
 
 source_catalog = config['kowalski']['collections']['sources']
+alerts_catalog = config['kowalski']['collections']['alerts']
 gaia_catalog = config['kowalski']['collections']['gaia']
 
-kowalski_instances = {'gloria': gloria, 'melman': melman}
+kowalski_instances = {'kowalski': kowalski, 'gloria': gloria, 'melman': melman}
 
 
 def drop_close_bright_stars(
@@ -69,6 +78,9 @@ def drop_close_bright_stars(
         Default is 300 corresponding with approximate maximum from A. Drake's exclusion radius (float)
     :param xmatch_radius_arcsec: size of cone within which to match a queried source with an input source.
         If any sources from the query fall within this cone, the closest one will be matched to the input source and dropped from further bright-star considerations (float)
+    :param limit: batch size of kowalski_instance queries (int)
+
+    :return id_dct_keep: dictionary containing subset of input sources far enough away from bright stars
     """
 
     ids = [x for x in id_dct]
@@ -193,11 +205,12 @@ def drop_close_bright_stars(
     return id_dct_keep
 
 
-# def generate_features(source_catalog=source_catalog, gaia_catalog=gaia_catalog, bright_star_query_radius_arcsec=300.,
+# def generate_features(source_catalog=source_catalog, alerts_catalog=alerts_catalog, gaia_catalog=gaia_catalog, bright_star_query_radius_arcsec=300.,
 # xmatch_radius_arcsec=2., kowalski_instances = kowalski_instances, limit=10000, doAllFields=False, field=296, doAllCCDs=False,
 # ccd=1, doAllQuads=False, quad=1, min_n_lc_points=50, min_cadence_minutes=30., dirname='generated_features', filename='features', doNotSave=False):
 def generate_features(
     source_catalog=source_catalog,
+    alerts_catalog=alerts_catalog,
     gaia_catalog=gaia_catalog,
     bright_star_query_radius_arcsec=300.0,
     xmatch_radius_arcsec=2.0,
@@ -301,6 +314,19 @@ def generate_features(
         except ValueError:
             feature_dict.pop(_id)
 
+    # Get ZTF alert stats
+    alert_stats_dct = alertstats.get_ztf_alert_stats(
+        feature_dict,
+        kowalski_instance=kowalski_instances['kowalski'],
+        radius_arcsec=xmatch_radius_arcsec,
+        limit=limit,
+    )
+    for _id in feature_dict.keys():
+        feature_dict[_id]['n_ztf_alerts'] = alert_stats_dct[_id]['n_ztf_alerts']
+        feature_dict[_id]['mean_ztf_alert_braai'] = alert_stats_dct[_id][
+            'mean_ztf_alert_braai'
+        ]
+
     feature_df = pd.DataFrame.from_dict(feature_dict, orient='index')
     utcnow = datetime.utcnow()
     end_dt = utcnow.strftime("%Y-%m-%d %H:%M:%S")
@@ -310,6 +336,7 @@ def generate_features(
     feature_df.attrs['feature_generation_start_dateTime_utc'] = start_dt
     feature_df.attrs['feature_generation_end_dateTime_utc'] = end_dt
     feature_df.attrs['ZTF_source_catalog'] = source_catalog
+    feature_df.attrs['ZTF_alerts_catalog'] = alerts_catalog
     feature_df.attrs['Gaia_catalog'] = gaia_catalog
 
     # Write results
@@ -336,6 +363,11 @@ if __name__ == "__main__":
         "-source_catalog",
         default=source_catalog,
         help="name of source collection on Kowalski",
+    )
+    parser.add_argument(
+        "-alerts_catalog",
+        default=alerts_catalog,
+        help="name of alerts collection on Kowalski",
     )
     parser.add_argument(
         "-gaia_catalog",
@@ -410,6 +442,7 @@ if __name__ == "__main__":
     # call generate_features
     generate_features(
         source_catalog=args.source_catalog,
+        alerts_catalog=args.alerts_catalog,
         gaia_catalog=args.gaia_catalog,
         bright_star_query_radius_arcsec=args.bright_star_query_radius_arcsec,
         xmatch_radius_arcsec=args.xmatch_radius_arcsec,


### PR DESCRIPTION
This PR adds code to get the `n_ztf_alerts` and `mean_ztf_alert_braai` features from the `ZTF_alerts` catalog on `kowalski`. The new code in `tools/featureGeneration/alertstats.py` is called by `generate_features.py`.

Since my `kowalski` token is different than the one that covers `gloria` and `melman`, I added an `alt_token:` field in `config.defaults.yaml` to allow me to authenticate a `kowalski` instance for the alerts. In this file there is also a new `alerts` field that allows the user to specify the name of the alerts collection.