### PR TITLE
Fix failing doc tests

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -265,8 +265,6 @@ class Scope:
         }
         response = self.kowalski.query(query=query)
         light_curves_raw = response.get("data").get(catalog).get("target")
-        print(light_curves_raw)
-        print(len(light_curves_raw))
 
         light_curves = []
         for light_curve in light_curves_raw:

--- a/scope.py
+++ b/scope.py
@@ -218,7 +218,7 @@ class Scope:
         self,
         ra: float,
         dec: float,
-        catalog: str = "ZTF_sources_20201201",
+        catalog: str = "ZTF_sources_20210401",
         cone_search_radius: Union[float, int] = 2,
         cone_search_unit: str = "arcsec",
         filter_flagged_data: bool = True,
@@ -265,6 +265,8 @@ class Scope:
         }
         response = self.kowalski.query(query=query)
         light_curves_raw = response.get("data").get(catalog).get("target")
+        print(light_curves_raw)
+        print(len(light_curves_raw))
 
         light_curves = []
         for light_curve in light_curves_raw:
@@ -405,7 +407,7 @@ class Scope:
                 sample_light_curves = self._get_light_curve_data(
                     ra=sample_object["coordinates"][0],
                     dec=sample_object["coordinates"][1],
-                    catalog=self.config["kowalski"]["collections"]["sources"],
+                    # catalog=self.config["kowalski"]["collections"]["sources"],
                 )
                 plot_light_curve_data(
                     light_curve_data=sample_light_curves,


### PR DESCRIPTION
This PR fixes the failing doc tests seen after today's PRs have been merged. The source of the failures is the updated config-default source catalog (ZTF DR15, `ZTF_sources_20230109`), which is only available on `melman.caltech.edu`. Since `gloria` is still relied upon for many scripts in scope, it would be disruptive to change the default host to `melman`. Instead, this PR comments out the line providing the config-default catalog in `scope.py doc`. The code now defaults to the `ZTF_sources_20210401` (DR5) specified in the `catalog` argument for `_get_light_curve_data()`.

In the future, hopefully this line can be uncommented and a `KowalskiInstances` class will manage the various instances more seamlessly.