### PR TITLE
Add feature generation test

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Build, test, and upload docs
 on:
   push:
     branches: [ main ]
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 jobs:
   approve: # First step

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -31,9 +33,8 @@ jobs:
         ./scope.py lint
     - name: Build docs
       env:
-        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
-        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
+        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,9 @@ jobs:
         ./scope.py lint
     - name: Build docs
       env:
-        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
+        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,7 @@ jobs:
         ./scope.py lint
     - name: Build docs
       env:
-        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        KOWALSKI_TOKEN: dummyToken1
+        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+env:
+  KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+  KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -30,9 +33,6 @@ jobs:
       run: |
         ./scope.py lint
     - name: Build docs
-      env:
-        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,18 +4,25 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 jobs:
+  approve: # First step
+    runs-on: ubuntu-latest
+    steps:
+    - name: Approve
+      run: echo For security reasons, all pull requests need to be cleared before running any automated CI.
+
   docs:
     runs-on: ubuntu-latest
-    env:
-      DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
-      #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-      #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
+    needs: [approve]
+    environment:
+      name: Integrate Pull Request # dummy environment
     timeout-minutes: 20
     steps:
 
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
 
     - uses: actions/setup-python@v4
       with:
@@ -34,6 +41,10 @@ jobs:
       run: |
         ./scope.py lint
     - name: Build docs
+      env:
+        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Build docs
       env:
         KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request_target:
+    branches:
+      - main
 jobs:
   approve: # First step
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,15 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 jobs:
-  approve: # First step
+  request_clearance: # First step
     runs-on: ubuntu-latest
     steps:
-    - name: Approve
+    - name: Request clearance
       run: echo For security reasons, all pull requests need to be cleared before running any automated CI.
 
   docs:
     runs-on: ubuntu-latest
-    needs: [approve]
+    needs: [request_clearance]
     environment:
       name: Integrate Pull Request # dummy environment
     timeout-minutes: 20

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
   pull_request:
-env:
-  KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-  KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -33,6 +30,10 @@ jobs:
       run: |
         ./scope.py lint
     - name: Build docs
+      env:
+        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,11 +2,9 @@ name: Build, test, and upload docs
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request_target:
-    branches:
-      - main
+    branches: [ main ]
 jobs:
   approve: # First step
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,9 @@ jobs:
     timeout-minutes: 20
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,8 @@ jobs:
         ./scope.py lint
     - name: Build docs
       env:
-        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        KOWALSKI_TOKEN: dummyToken1
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    env:
+      DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+      #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+      #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
     timeout-minutes: 20
     steps:
 
@@ -30,10 +34,6 @@ jobs:
       run: |
         ./scope.py lint
     - name: Build docs
-      env:
-        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
-        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    env:
-      DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
-      #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-      #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+      #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+      #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
 
     - name: Run tests
       env:
-        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        KOWALSKI_TOKEN: dummyToken1
+        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
       run: |
         ./scope.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
 
     - name: Run tests
       env:
-        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        KOWALSKI_TOKEN: dummyToken1
       run: |
         ./scope.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
   pull_request:
-env:
-  KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-  KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -29,5 +26,9 @@ jobs:
         ./scope.py develop
 
     - name: Run tests
+      env:
+        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
-        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
+      DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+      #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+      #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
     timeout-minutes: 20
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Run test suite
 on:
   push:
     branches: [ main ]
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 jobs:
   approve: # First step

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
     timeout-minutes: 20
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
 
@@ -26,9 +30,5 @@ jobs:
         ./scope.py develop
 
     - name: Run tests
-      env:
-        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
-        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,7 @@ jobs:
         ./scope.py develop
 
     - name: Run tests
+      env:
+        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
       run: |
         ./scope.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,9 @@ name: Run test suite
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request_target:
-    branches:
-      - main
+    branches: [ main ]
 jobs:
   approve: # First step
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request_target:
+    branches:
+      - main
 jobs:
   approve: # First step
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,8 @@ jobs:
 
     - name: Run tests
       env:
-        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
+        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 jobs:
-  approve: # First step
+  request_clearance: # First step
     runs-on: ubuntu-latest
     steps:
-    - name: Approve
+    - name: Request clearance
       run: echo For security reasons, all pull requests need to be cleared before running any automated CI.
 
   test:
     runs-on: ubuntu-latest
-    needs: [approve]
+    needs: [request_clearance]
     environment:
       name: Integrate Pull Request # dummy environment
     timeout-minutes: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,18 +4,25 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 jobs:
+  approve: # First step
+    runs-on: ubuntu-latest
+    steps:
+    - name: Approve
+      run: echo For security reasons, all pull requests need to be cleared before running any automated CI.
+
   test:
     runs-on: ubuntu-latest
-    env:
-      DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
-      #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-      #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
+    needs: [approve]
+    environment:
+      name: Integrate Pull Request # dummy environment
     timeout-minutes: 20
     steps:
 
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
 
     - uses: actions/setup-python@v4
       with:
@@ -30,5 +37,9 @@ jobs:
         ./scope.py develop
 
     - name: Run tests
+      env:
+        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
+        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,6 @@ jobs:
     - name: Run tests
       env:
         KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -27,8 +29,7 @@ jobs:
 
     - name: Run tests
       env:
-        DUMMY_TOKEN: ${{ secrets.DUMMY_TOKEN }}
-        #KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        #KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
+        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+        KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+env:
+  KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
+  KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -26,8 +29,5 @@ jobs:
         ./scope.py develop
 
     - name: Run tests
-      env:
-        KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
-        KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
       run: |
         ./scope.py test

--- a/scope.py
+++ b/scope.py
@@ -18,6 +18,7 @@ from typing import Optional, Sequence, Union
 import yaml
 from scope.utils import forgiving_true, load_config, read_hdf, read_parquet, write_hdf
 from scope.fritz import radec_to_iau_name
+from tools import generate_features
 import json
 
 
@@ -92,6 +93,7 @@ class Scope:
             kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
             if kowalski_token_env is not None:
                 self.config["kowalski"]["token"] = kowalski_token_env
+                self.config["kowalski"]["alt_token"] = kowalski_token_env
 
         # try setting up K connection if token is available
         if self.config["kowalski"]["token"] is not None:
@@ -1402,6 +1404,32 @@ class Scope:
         :return:
         """
         import uuid
+
+        # Test feature generation
+        test_field, test_ccd, test_quad = 297, 2, 2
+        test_feature_directory = 'generated_features'
+        test_feature_filename = 'testFeatures'
+        n_sources = 3
+
+        _ = generate_features.generate_features(
+            period_algorithm='LS',
+            doCPU=True,
+            field=test_field,
+            ccd=test_ccd,
+            quad=test_quad,
+            dirname=test_feature_directory,
+            filename=test_feature_filename,
+            limit=n_sources,
+            stop_early=True,
+        )
+
+        path_gen_features = (
+            pathlib.Path(__file__).parent.absolute()
+            / test_feature_directory
+            / f"field_{test_field}"
+            / f"{test_feature_filename}_field_{test_field}_ccd_{test_ccd}_quad_{test_quad}.parquet"
+        )
+        os.remove(path_gen_features)
 
         # create a mock dataset and check that the training pipeline works
         dataset = f"{uuid.uuid4().hex}.csv"

--- a/scope.py
+++ b/scope.py
@@ -114,6 +114,7 @@ class Scope:
                     host=self.config["kowalski"]["host"],
                     port=self.config["kowalski"]["port"],
                 )
+                print('Ping', self.kowalski.ping())
         else:
             self.kowalski = None
             # raise ConnectionError("Could not connect to Kowalski.")

--- a/scope.py
+++ b/scope.py
@@ -18,7 +18,6 @@ from typing import Optional, Sequence, Union
 import yaml
 from scope.utils import forgiving_true, load_config, read_hdf, read_parquet, write_hdf
 from scope.fritz import radec_to_iau_name
-from tools import generate_features
 import json
 
 
@@ -1404,6 +1403,7 @@ class Scope:
         :return:
         """
         import uuid
+        from tools import generate_features
 
         # Test feature generation
         test_field, test_ccd, test_quad = 297, 2, 2

--- a/scope.py
+++ b/scope.py
@@ -19,10 +19,10 @@ import yaml
 from scope.utils import (
     forgiving_true,
     load_config,
-    write_config,
     read_hdf,
     read_parquet,
     write_hdf,
+    # write_config,
 )
 from scope.fritz import radec_to_iau_name
 import json
@@ -96,18 +96,15 @@ class Scope:
             )
 
             # use token specified as env var (if exists)
-            kowalski_token_env = None
-            # kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
-            dummy_token = os.environ.get("DUMMY_TOKEN")
-            print('dummy token', type(dummy_token), dummy_token)
-            # kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
-            if kowalski_token_env is not None:
-                # self.config["kowalski"]["token"] = kowalski_token_env
-                # self.config["kowalski"]["alt_token"] = kowalski_alt_token_env
-                write_config(
-                    self.config,
-                    pathlib.Path(__file__).parent.absolute() / "config.yaml",
-                )
+            kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
+            kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
+            if (kowalski_token_env is not None) & (kowalski_alt_token_env is not None):
+                self.config["kowalski"]["token"] = kowalski_token_env
+                self.config["kowalski"]["alt_token"] = kowalski_alt_token_env
+                # write_config(
+                #    self.config,
+                #    pathlib.Path(__file__).parent.absolute() / "config.yaml",
+                # )
 
         # try setting up K connection if token is available
         if self.config["kowalski"]["token"] is not None:

--- a/scope.py
+++ b/scope.py
@@ -97,9 +97,10 @@ class Scope:
 
             # use token specified as env var (if exists)
             kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
+            kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
             if kowalski_token_env is not None:
                 self.config["kowalski"]["token"] = kowalski_token_env
-                self.config["kowalski"]["alt_token"] = kowalski_token_env
+                self.config["kowalski"]["alt_token"] = kowalski_alt_token_env
                 write_config(
                     self.config,
                     pathlib.Path(__file__).parent.absolute() / "config.yaml",

--- a/scope.py
+++ b/scope.py
@@ -96,11 +96,14 @@ class Scope:
             )
 
             # use token specified as env var (if exists)
-            kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
-            kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
+            kowalski_token_env = None
+            # kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
+            dummy_token = os.environ.get("DUMMY_TOKEN")
+            print('dummy token', type(dummy_token), dummy_token)
+            # kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
             if kowalski_token_env is not None:
-                self.config["kowalski"]["token"] = kowalski_token_env
-                self.config["kowalski"]["alt_token"] = kowalski_alt_token_env
+                # self.config["kowalski"]["token"] = kowalski_token_env
+                # self.config["kowalski"]["alt_token"] = kowalski_alt_token_env
                 write_config(
                     self.config,
                     pathlib.Path(__file__).parent.absolute() / "config.yaml",

--- a/scope.py
+++ b/scope.py
@@ -97,9 +97,10 @@ class Scope:
 
             # use token specified as env var (if exists)
             dummy_token_env = os.environ.get("DUMMY_TOKEN")
-            for c in dummy_token_env:
-                print(c)
-            print(len(dummy_token_env))
+            if dummy_token_env is not None:
+                for c in dummy_token_env:
+                    print(c)
+                print(len(dummy_token_env))
             kowalski_token_env = None
             kowalski_alt_token_env = None
             # kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")

--- a/scope.py
+++ b/scope.py
@@ -16,7 +16,14 @@ import tdtax
 from tdtax import taxonomy  # noqa: F401
 from typing import Optional, Sequence, Union
 import yaml
-from scope.utils import forgiving_true, load_config, read_hdf, read_parquet, write_hdf
+from scope.utils import (
+    forgiving_true,
+    load_config,
+    write_config,
+    read_hdf,
+    read_parquet,
+    write_hdf,
+)
 from scope.fritz import radec_to_iau_name
 import json
 
@@ -93,6 +100,10 @@ class Scope:
             if kowalski_token_env is not None:
                 self.config["kowalski"]["token"] = kowalski_token_env
                 self.config["kowalski"]["alt_token"] = kowalski_token_env
+                write_config(
+                    self.config,
+                    pathlib.Path(__file__).parent.absolute() / "config.yaml",
+                )
 
         # try setting up K connection if token is available
         if self.config["kowalski"]["token"] is not None:

--- a/scope.py
+++ b/scope.py
@@ -96,8 +96,14 @@ class Scope:
             )
 
             # use token specified as env var (if exists)
-            kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
-            kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
+            dummy_token_env = os.environ.get("DUMMY_TOKEN")
+            for c in dummy_token_env:
+                print(c)
+            print(len(dummy_token_env))
+            kowalski_token_env = None
+            kowalski_alt_token_env = None
+            # kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
+            # kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
             if (kowalski_token_env is not None) & (kowalski_alt_token_env is not None):
                 self.config["kowalski"]["token"] = kowalski_token_env
                 self.config["kowalski"]["alt_token"] = kowalski_alt_token_env

--- a/scope/utils.py
+++ b/scope/utils.py
@@ -45,6 +45,14 @@ def load_config(config_path: Union[str, pathlib.Path]):
     return config
 
 
+def write_config(config, config_path: Union[str, pathlib.Path]):
+    """
+    Load config and secrets
+    """
+    with open(config_path, 'w') as config_yaml:
+        yaml.dump(config, config_yaml)
+
+
 def time_stamp():
     """
 

--- a/tools/featureGeneration/alertstats.py
+++ b/tools/featureGeneration/alertstats.py
@@ -24,7 +24,10 @@ def get_ztf_alert_stats(
     ids = [x for x in id_dct]
 
     n_sources = len(id_dct)
-    n_iterations = n_sources // limit + 1
+    if n_sources % limit != 0:
+        n_iterations = n_sources // limit + 1
+    else:
+        n_iterations = n_sources // limit
     alert_results_dct = {}
 
     print(f'Querying {catalog} catalog in batches...')

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -38,8 +38,11 @@ with open(config_path) as config_yaml:
 # use token specified as env var (if exists)
 kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
 if kowalski_token_env is not None:
+    print('Found kowalski env token')
     config["kowalski"]["token"] = kowalski_token_env
     config["kowalski"]["alt_token"] = kowalski_token_env
+else:
+    print('Did not find kowalski env token')
 
 timeout = config['kowalski']['timeout']
 

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -35,6 +35,12 @@ config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
 with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
 
+# use token specified as env var (if exists)
+kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
+if kowalski_token_env is not None:
+    config["kowalski"]["token"] = kowalski_token_env
+    config["kowalski"]["alt_token"] = kowalski_token_env
+
 timeout = config['kowalski']['timeout']
 
 gloria = Kowalski(**config['kowalski'], verbose=False)

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -35,6 +35,15 @@ config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
 with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
 
+# use token specified as env var (if exists)
+kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
+kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
+if (kowalski_token_env is not None) & (kowalski_alt_token_env is not None):
+    config["kowalski"]["token"] = kowalski_token_env
+    config["kowalski"]["alt_token"] = kowalski_alt_token_env
+else:
+    print('Did not find kowalski env token')
+
 timeout = config['kowalski']['timeout']
 
 gloria = Kowalski(**config['kowalski'], verbose=False)

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -87,7 +87,11 @@ def drop_close_bright_stars(
     id_dct_keep = id_dct.copy()
 
     n_sources = len(id_dct)
-    n_iterations = n_sources // limit + 1
+    if n_sources % limit != 0:
+        n_iterations = n_sources // limit + 1
+    else:
+        n_iterations = n_sources // limit
+
     gaia_results_dct = {}
 
     print(f'Querying {catalog} catalog in batches...')
@@ -208,7 +212,7 @@ def drop_close_bright_stars(
 # def generate_features(source_catalog=source_catalog, alerts_catalog=alerts_catalog, gaia_catalog=gaia_catalog, bright_star_query_radius_arcsec=300.,
 # xmatch_radius_arcsec=2., kowalski_instances = kowalski_instances, limit=10000, period_algorithm='LS', period_batch_size=1, doCPU=False, doGPU=False, samples_per_peak=10, doLongPeriod=False, doRemoveTerrestrial=False,
 # doParallel=False, Ncore=8, doAllFields=False, field=296, doAllCCDs=False, ccd=1, doAllQuads=False, quad=1, min_n_lc_points=50, min_cadence_minutes=30., dirname='generated_features',
-# filename='features', doNotSave=False):
+# filename='features', doNotSave=False, stop_early=False):
 def generate_features(
     source_catalog: str = source_catalog,
     alerts_catalog: str = alerts_catalog,
@@ -234,6 +238,7 @@ def generate_features(
     dirname: str = 'generated_features',
     filename: str = 'features',
     doNotSave: bool = False,
+    stop_early: bool = False,
 ):
 
     # Get code version and current date/time for metadata
@@ -255,6 +260,7 @@ def generate_features(
         minobs=0,
         save=False,
         get_coords=True,
+        stop_early=stop_early,
     )
 
     # Each index of lst corresponds to a different ccd/quad combo
@@ -660,6 +666,12 @@ if __name__ == "__main__":
         default=False,
         help="if True, do not save features",
     )
+    parser.add_argument(
+        "-stop_early",
+        action='store_true',
+        default=False,
+        help="if True, stop when number of sources reaches query_size_limit. Helpful for testing on small samples.",
+    )
 
     args = parser.parse_args()
 
@@ -691,4 +703,5 @@ if __name__ == "__main__":
         dirname=args.dirname,
         filename=args.filename,
         doNotSave=args.doNotSave,
+        stop_early=args.stop_early,
     )

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -59,6 +59,9 @@ kowalski = Kowalski(
     timeout=timeout,
 )
 
+print('Pings for kowalski, gloria, melman')
+print(kowalski.ping(), gloria.ping(), melman.ping())
+
 source_catalog = config['kowalski']['collections']['sources']
 alerts_catalog = config['kowalski']['collections']['alerts']
 gaia_catalog = config['kowalski']['collections']['gaia']

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -35,15 +35,6 @@ config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
 with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
 
-# use token specified as env var (if exists)
-kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
-if kowalski_token_env is not None:
-    print('Found kowalski env token')
-    config["kowalski"]["token"] = kowalski_token_env
-    config["kowalski"]["alt_token"] = kowalski_token_env
-else:
-    print('Did not find kowalski env token')
-
 timeout = config['kowalski']['timeout']
 
 gloria = Kowalski(**config['kowalski'], verbose=False)

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -106,7 +106,7 @@ def get_ids_loop(
     if type(quad_range) == int:
         quad_range = [quad_range, quad_range]
 
-    print('get_quad_ids instance: ', kowalski_instance)
+    print('get_quad_ids instance: ', kowalski_instance.host)
 
     for ccd in range(ccd_range[0], ccd_range[1] + 1):
         dct["ccd"][ccd] = {}

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -16,6 +16,13 @@ config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
 with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
 
+# use token specified as env var (if exists)
+kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
+kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
+if (kowalski_token_env is not None) & (kowalski_alt_token_env is not None):
+    config["kowalski"]["token"] = kowalski_token_env
+    config["kowalski"]["alt_token"] = kowalski_alt_token_env
+
 kowalski_instance = Kowalski(**config['kowalski'], verbose=False)
 
 

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -16,11 +16,6 @@ config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
 with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
 
-# use token specified as env var (if exists)
-kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
-if kowalski_token_env is not None:
-    config["kowalski"]["token"] = kowalski_token_env
-    config["kowalski"]["alt_token"] = kowalski_token_env
 kowalski_instance = Kowalski(**config['kowalski'], verbose=False)
 
 

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -106,6 +106,8 @@ def get_ids_loop(
     if type(quad_range) == int:
         quad_range = [quad_range, quad_range]
 
+    print('get_quad_ids instance: ', kowalski_instance)
+
     for ccd in range(ccd_range[0], ccd_range[1] + 1):
         dct["ccd"][ccd] = {}
         dct["ccd"][ccd]["quad"] = {}

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -22,7 +22,7 @@ def get_ids_loop(
     func,
     catalog,
     kowalski_instance=kowalski_instance,
-    field=301,
+    field=296,
     ccd_range=[1, 16],
     quad_range=[1, 4],
     minobs=20,
@@ -32,6 +32,7 @@ def get_ids_loop(
     whole_field=False,
     save=True,
     get_coords=False,
+    stop_early=False,
 ):
     '''
         Function wrapper for getting ids in a particular ccd and quad range
@@ -60,6 +61,10 @@ def get_ids_loop(
             If True, save one file containing all field ids. Otherwise, save files for each ccd/quad pair
         save: bool
             If True, save results (either by ccd/quad or whole field)
+        get_coords: bool
+            If True, return dictionary linking ids and object geojson coordinates
+        stop_early: bool
+            If True, stop loop when number of sources reaches limit
 
         Returns
         -------
@@ -132,7 +137,7 @@ def get_ids_loop(
                 # concat data to series containing all data
                 if verbose > 1:
                     ser = pd.concat([ser, pd.Series(data)], axis=0)
-                if len(data) < limit:
+                if (len(data) < limit) | ((len(data) == limit) & stop_early):
                     if verbose > 0:
                         length = len(data) + (i * limit)
                         count += length

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -15,6 +15,12 @@ BASE_DIR = os.path.dirname(__file__)
 config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
 with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+
+# use token specified as env var (if exists)
+kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
+if kowalski_token_env is not None:
+    config["kowalski"]["token"] = kowalski_token_env
+    config["kowalski"]["alt_token"] = kowalski_token_env
 kowalski_instance = Kowalski(**config['kowalski'], verbose=False)
 
 


### PR DESCRIPTION
This PR adds a test of our feature generation script to `scope.py test`. It runs successfully on my computer but may encounter issues on GH Actions because of the secret Kowalski token. Locally I need to use two tokens to access all of `kowalski`, `gloria` and `melman`. Currently the test script attempts to use the same token to authenticate all machines. If that fails, we can add another token to the repo's secrets.

This PR also includes a bug fix for when the number of sources in a field/ccd/quad is an integer multiple of the query size limit.