### PR TITLE
Change condition for deploying docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,14 +47,14 @@ jobs:
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑
-      if: github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'
       uses: webfactory/ssh-agent@v0.4.1
       with:
         ssh-private-key: ${{ secrets.CI_DEPLOY_KEY }}
 
     - name: Deploy docs
-      if: github.ref == 'refs/heads/main'
-      uses: JamesIves/github-pages-deploy-action@releases/v3
+      if: github.event_name == 'push'
+      uses: JamesIves/github-pages-deploy-action@releases/v4
       with:
         FOLDER: doc/_build/html
         REPOSITORY_NAME: ZwickyTransientFacility/scope-docs


### PR DESCRIPTION
The new tests are passing except for a failed docs deployment. The docs workflow should not even be attempting to deploy until a PR is merged, so something is not working as it used to. This PR changes the condition for deploying docs within Github Actions.

I think the change from `pull_request` to `pull_request_target` sets `github.ref` to `'refs/head/main'` even within a PR branch. This triggers a failed deployment attempt even though there is no merge happening. The change to `if: github.event_name == 'push'` should fix this, but that will not be reflected in the tests for this PR.


