### PR TITLE
Add cone search queries for external catalog features

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1337,6 +1337,7 @@ feature_generation:
         w2mpro : 1
         w2sigmpro : 1
         w3mpro : 1
+        w3sigmpro : 1
         w4mpro : 1
         w4sigmpro : 1
         ph_qual : 1

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1325,6 +1325,52 @@ feature_stats:
     mean: 0.01834675346206806
     std: 0.021816145036886694
 
+# Below, specify external catalogs and features to include in generated feature lists:
+feature_generation:
+  external_catalog_features:
+    AllWISE:
+      filter: {}
+      projection:
+        _id : 1
+        w1mpro : 1
+        w1sigmpro : 1
+        w2mpro : 1
+        w2sigmpro : 1
+        w3mpro : 1
+        w4mpro : 1
+        w4sigmpro : 1
+        ph_qual : 1
+    Gaia_EDR3:
+      filter: {}
+      projection:
+        _id : 1
+        phot_g_mean_mag : 1
+        phot_bp_mean_mag : 1
+        phot_rp_mean_mag : 1
+        parallax : 1
+        parallax_error : 1
+        pmra : 1
+        pmra_error : 1
+        pmdec : 1
+        pmdec_error : 1
+        astrometric_excess_noise : 1
+        phot_bp_rp_excess_factor : 1
+    PS1_DR1:
+      filter: {}
+      projection:
+        _id : 1
+        gMeanPSFMag : 1
+        gMeanPSFMagErr : 1
+        rMeanPSFMag : 1
+        rMeanPSFMagErr : 1
+        iMeanPSFMag : 1
+        iMeanPSFMagErr : 1
+        zMeanPSFMag : 1
+        zMeanPSFMagErr : 1
+        yMeanPSFMag : 1
+        yMeanPSFMagErr : 1
+        qualityFlag : 1
+
 training:
   # Below, enter path to training set
   dataset: tools/fritzDownload/merged_classifications_features.parquet

--- a/tools/featureGeneration/external_xmatch.py
+++ b/tools/featureGeneration/external_xmatch.py
@@ -1,0 +1,83 @@
+import numpy as np
+from penquins import Kowalski
+
+
+def xmatch(
+    id_dct: dict,
+    kowalski_instance: Kowalski,
+    catalog_info: dict,
+    radius_arcsec: float = 2.0,
+    limit: int = 10000,
+):
+    """
+    Batch cross-match external catalogs by position
+
+    :param id_dct: one quadrant's worth of id-coordinate pairs (dict)
+    :param kowalski_instance: authenticated instance of a Kowalski database
+    :param catalog_info: nested dict containing catalog names, filters and projections (see config.yaml)
+    :param xmatch_radius_arcsec: size of cone within which to match a queried source with an input source.
+    :param limit: batch size of kowalski_instance queries (int)
+
+    :return id_dct_external: id_dct updated with external xmatch values
+    """
+
+    n_sources = len(id_dct)
+    if n_sources % limit != 0:
+        n_iterations = n_sources // limit + 1
+    else:
+        n_iterations = n_sources // limit
+    ext_results_dct = {}
+
+    print('Querying crossmatch catalogs in batches...')
+    for i in range(0, n_iterations):
+        print(f"Iteration {i+1} of {n_iterations}...")
+        id_slice = [x for x in id_dct.keys()][
+            i * limit : min(n_sources, (i + 1) * limit)
+        ]
+
+        radec_geojson = np.array(
+            [id_dct[x]['radec_geojson']['coordinates'] for x in id_slice]
+        ).transpose()
+
+        # Need to add 180 -> no negative RAs
+        radec_geojson[0, :] += 180.0
+
+        # Get external catalog data
+        query = {
+            "query_type": "cone_search",
+            "query": {
+                "object_coordinates": {
+                    "radec": dict(zip(id_slice, radec_geojson.transpose().tolist())),
+                    "cone_search_radius": radius_arcsec,
+                    "cone_search_unit": 'arcsec',
+                },
+                "catalogs": catalog_info,
+                "filter": {},
+            },
+        }
+        q = kowalski_instance.query(query)
+
+        ext_results = q['data']
+        ext_results_dct.update(ext_results)
+
+    id_dct_external = id_dct.copy()
+    print('Iterating through results and assigning xmatch features to sources...')
+    for catalog in catalog_info.keys():
+        cat_results = ext_results_dct[catalog]
+        cat_projection_names = [x for x in catalog_info[catalog]['projection'].keys()]
+        for id in id_dct_external.keys():
+            ext_values = cat_results[str(id)]
+            if len(ext_values) > 0:
+                ext_values = ext_values[0]
+                for val_name in cat_projection_names:
+                    try:
+                        id_dct_external[id][f'{catalog}__{val_name}'] = ext_values[
+                            val_name
+                        ]
+                    except KeyError:
+                        id_dct_external[id][f'{catalog}__{val_name}'] = np.nan
+            else:
+                for val_name in cat_projection_names:
+                    id_dct_external[id][f'{catalog}__{val_name}'] = np.nan
+
+    return id_dct_external

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -18,7 +18,7 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from datetime import datetime
-from tools.featureGeneration import lcstats, periodsearch, alertstats
+from tools.featureGeneration import lcstats, periodsearch, alertstats, external_xmatch
 import warnings
 
 # import time
@@ -63,6 +63,7 @@ kowalski = Kowalski(
 source_catalog = config['kowalski']['collections']['sources']
 alerts_catalog = config['kowalski']['collections']['alerts']
 gaia_catalog = config['kowalski']['collections']['gaia']
+ext_catalog_info = config['feature_generation']['external_catalog_features']
 
 kowalski_instances = {'kowalski': kowalski, 'gloria': gloria, 'melman': melman}
 
@@ -451,7 +452,7 @@ def generate_features(
         if (idx + 1) % limit == 0:
             print(f"{count} done")
         if count == len(keep_id_list):
-            print(f"{count} done")
+            print(f"{count} meeting min_n_lc_points requirement done")
 
         period = periods[idx]
         significance = significances[idx]
@@ -508,10 +509,22 @@ def generate_features(
             'mean_ztf_alert_braai'
         ]
 
-    # Add crossmatches to Gaia, AllWISE and PS1 (call xmatch.py)
-    #
-
+    # Add crossmatches to Gaia, AllWISE and PS1 (by default, see config.yaml)
+    feature_dict = external_xmatch.xmatch(
+        feature_dict,
+        kowalski_instances['gloria'],
+        catalog_info=ext_catalog_info,
+        radius_arcsec=xmatch_radius_arcsec,
+        limit=limit,
+    )
     feature_df = pd.DataFrame.from_dict(feature_dict, orient='index')
+
+    # Convert mixed _id datatypes to Int64
+    colnames = [x for x in feature_df.columns]
+    for col in colnames:
+        if '_id' in col:
+            feature_df[col] = feature_df[col].astype("Int64")
+
     utcnow = datetime.utcnow()
     end_dt = utcnow.strftime("%Y-%m-%d %H:%M:%S")
 

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -519,7 +519,7 @@ def generate_features(
     )
     feature_df = pd.DataFrame.from_dict(feature_dict, orient='index')
 
-    # Convert mixed _id datatypes to Int64
+    # Convert various _id datatypes to Int64
     colnames = [x for x in feature_df.columns]
     for col in colnames:
         if '_id' in col:


### PR DESCRIPTION
This PR adds external catalog crossmatches via cone search to the feature generation script. It adds a new section of the config file to specify which external features to get, then passes that info to `tools/featureGeneration/external_xmatch.py` which runs batch queries. The external features are incorporated into the existing set produced by `generate_features.py`. 