### PR TITLE
Pin scope-phenomenology

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "periodfind"]
 	path = periodfind
 	url = git@github.com:ejaszewski/periodfind.git
+[submodule "scope-phenomenology"]
+	path = scope-phenomenology
+	url = git@github.com:bfhealy/scope-phenomenology.git


### PR DESCRIPTION
This PR pins the [scope-phenomenology](https://github.com/bfhealy/scope-phenomenology) repo, which contains the SCoPe Phenomenological Taxonomy used on Fritz. This removes the need to clone the repo separately from scope.