### PR TITLE
Only deploy docs if merging to ZTF-owned scope repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,13 +47,13 @@ jobs:
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.repository_owner == 'ZwickyTransientFacility'
       uses: webfactory/ssh-agent@v0.4.1
       with:
         ssh-private-key: ${{ secrets.CI_DEPLOY_KEY }}
 
     - name: Deploy docs
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.repository_owner == 'ZwickyTransientFacility'
       uses: JamesIves/github-pages-deploy-action@releases/v4
       with:
         FOLDER: doc/_build/html


### PR DESCRIPTION
This PR modifies the `docs` workflow to only attempt documentation deployment for pushes to the ZTF-owned scope repo (this one).

This should change nothing about actions behavior in this repo, but it should fix failing tests when pushing to forked repos and protect the docs from unintended deployments.