### PR TITLE
Add option to generate cesium features

### DIFF
--- a/.requirements/doc.txt
+++ b/.requirements/doc.txt
@@ -13,3 +13,4 @@ sphinx_press_theme
 tdtax>=0.1.3
 tables>=3.7
 pyarrow>=9.0.0
+cesium

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1327,6 +1327,130 @@ feature_stats:
 
 # Below, specify external catalogs and features to include in generated feature lists:
 feature_generation:
+  cesium_features:
+    # Some features on this list are already computed by lcstats - these are commented below
+    #
+    # Cadence/Error:
+    #
+    #- n_epochs
+    - avg_err
+    - med_err
+    - std_err
+    - total_time
+    - avgt
+    - cads_std
+    - mean
+    - cads_avg
+    - cads_med
+    - cad_probs_1
+    - cad_probs_10
+    - cad_probs_20
+    - cad_probs_30
+    - cad_probs_40
+    - cad_probs_50
+    - cad_probs_100
+    - cad_probs_500
+    - cad_probs_1000
+    - cad_probs_5000
+    - cad_probs_10000
+    - cad_probs_50000
+    - cad_probs_100000
+    - cad_probs_500000
+    - cad_probs_1000000
+    - cad_probs_5000000
+    - cad_probs_10000000
+    - med_double_to_single_step
+    - avg_double_to_single_step
+    - std_double_to_single_step
+    - all_times_nhist_numpeaks
+    - all_times_nhist_peak_val
+    - all_times_nhist_peak_1_to_2
+    - all_times_nhist_peak_1_to_3
+    - all_times_nhist_peak_2_to_3
+    - all_times_nhist_peak_1_to_4
+    - all_times_nhist_peak_2_to_4
+    - all_times_nhist_peak_3_to_4
+    - all_times_nhist_peak1_bin
+    - all_times_nhist_peak2_bin
+    - all_times_nhist_peak3_bin
+    - all_times_nhist_peak4_bin
+    #
+    # General:
+    #
+    - amplitude
+    - flux_percentile_ratio_mid20
+    - flux_percentile_ratio_mid35
+    - flux_percentile_ratio_mid50
+    - flux_percentile_ratio_mid65
+    - flux_percentile_ratio_mid80
+    - max_slope
+    - maximum
+    #- median
+    #- median_absolute_deviation
+    - minimum
+    - percent_amplitude
+    - percent_beyond_1_std
+    - percent_close_to_median
+    - percent_difference_flux_percentile
+    - period_fast
+    - qso_log_chi2_qsonu
+    - qso_log_chi2nuNULL_chi2nu
+    - skew
+    - std
+    #- stetson_j
+    #- stetson_k
+    #- weighted_average
+    #
+    # Lomb-Scargle (Periodic):
+    #
+    # These features require a second period analysis - commented by default
+    # - fold2P_slope_10percentile
+    # - fold2P_slope_90percentile
+    # - freq1_amplitude1
+    # - freq1_amplitude2
+    # - freq1_amplitude3
+    # - freq1_amplitude4
+    # - freq1_freq
+    # - freq1_lambda
+    # - freq1_rel_phase2
+    # - freq1_rel_phase3
+    # - freq1_rel_phase4
+    # - freq1_signif
+    # - freq2_amplitude1
+    # - freq2_amplitude2
+    # - freq2_amplitude3
+    # - freq2_amplitude4
+    # - freq2_freq
+    # - freq2_rel_phase2
+    # - freq2_rel_phase3
+    # - freq2_rel_phase4
+    # - freq3_amplitude1
+    # - freq3_amplitude2
+    # - freq3_amplitude3
+    # - freq3_amplitude4
+    # - freq3_freq
+    # - freq3_rel_phase2
+    # - freq3_rel_phase3
+    # - freq3_rel_phase4
+    # - freq_amplitude_ratio_21
+    # - freq_amplitude_ratio_31
+    # - freq_frequency_ratio_21
+    # - freq_frequency_ratio_31
+    # - freq_model_max_delta_mags
+    # - freq_model_min_delta_mags
+    # - freq_model_phi1_phi2
+    # - freq_n_alias
+    # - freq_signif_ratio_21
+    # - freq_signif_ratio_31
+    # - freq_varrat
+    # - freq_y_offset
+    # - linear_trend
+    # - medperc90_2p_p
+    # - p2p_scatter_2praw
+    # - p2p_scatter_over_mad
+    # - p2p_scatter_pfold_over_mad
+    # - p2p_ssqr_diff_over_var
+    # - scatter_res_raw
   external_catalog_features:
     AllWISE:
       filter: {}

--- a/scope.py
+++ b/scope.py
@@ -1427,6 +1427,7 @@ class Scope:
             dirname=test_feature_directory,
             filename=test_feature_filename,
             limit=n_sources,
+            doCesium=True,
             stop_early=True,
         )
 

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -26,7 +26,6 @@ from cesium.featurize import time_series, featurize_single_ts
 # import time
 # import periodfind
 # from numba import jit
-# import cesium.features as fts
 
 
 BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -218,10 +218,6 @@ def drop_close_bright_stars(
     return id_dct_keep
 
 
-# def generate_features(source_catalog=source_catalog, alerts_catalog=alerts_catalog, gaia_catalog=gaia_catalog, bright_star_query_radius_arcsec=300.,
-# xmatch_radius_arcsec=2., kowalski_instances = kowalski_instances, limit=10000, period_algorithm='LS', period_batch_size=1, doCPU=False, doGPU=False, samples_per_peak=10, doLongPeriod=False, doRemoveTerrestrial=False,
-# doParallel=False, Ncore=8, doAllFields=False, field=296, doAllCCDs=False, ccd=1, doAllQuads=False, quad=1, min_n_lc_points=50, min_cadence_minutes=30., dirname='generated_features',
-# filename='features', doCesium=False, doNotSave=False, stop_early=False):
 def generate_features(
     source_catalog: str = source_catalog,
     alerts_catalog: str = alerts_catalog,


### PR DESCRIPTION
This PR allows users to generate cesium features in addition to the default scope/ztfperiodic features. The config file now contains the full list of available cesium features, and uncommented features will be generated if `-doCesium` is set in `generate_features.py`. 

Some overlapping features between scope/cesium and all periodic features are commented by default - the latter group because it requires an additional Lomb-Scargle analysis. Going forward we could modify cesium to accept a period from our existing analysis and compute Fourier features based on that value. 