### PR TITLE
Generate slurm scripts

### DIFF
--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -23,11 +23,6 @@ import warnings
 from cesium.featurize import time_series, featurize_single_ts
 
 
-# import time
-# import periodfind
-# from numba import jit
-
-
 BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()
 
 # setup connection to Kowalski instances
@@ -241,10 +236,13 @@ def generate_features(
     min_n_lc_points: int = 50,
     min_cadence_minutes: float = 30.0,
     dirname: str = 'generated_features',
-    filename: str = 'features',
+    filename: str = 'gen_features',
     doCesium: bool = False,
     doNotSave: bool = False,
     stop_early: bool = False,
+    doQuadrantFile: bool = False,
+    quadrant_file: str = 'slurm.dat',
+    quadrant_index: int = 0,
 ):
 
     # Get code version and current date/time for metadata
@@ -252,7 +250,20 @@ def generate_features(
     utcnow = datetime.utcnow()
     start_dt = utcnow.strftime("%Y-%m-%d %H:%M:%S")
 
-    # Add code for parallelization across fields/ccds/quads
+    # Code supporting parallelization across fields/ccds/quads
+    slurmDir = os.path.join(str(BASE_DIR / dirname), 'slurm')
+    if doQuadrantFile:
+        names = ["job_number", "field", "ccd", "quadrant"]
+        df_original = pd.read_csv(
+            os.path.join(slurmDir, quadrant_file),
+            header=None,
+            delimiter=' ',
+            names=names,
+        )
+        row = df_original.iloc[quadrant_index, :]
+        field, ccd, quad = int(row["field"]), int(row["ccd"]), int(row["quadrant"])
+
+    print(f'Running field {field}, CCD {ccd}, Quadrant {quad}...')
 
     print('Getting IDs...')
     _, lst = get_ids_loop(
@@ -405,149 +416,156 @@ def generate_features(
         except ValueError:
             feature_dict.pop(_id)
 
-    # Define frequency grid using largest LC time baseline
-    if doLongPeriod:
-        fmin, fmax = 2 / baseline, 48
-    else:
-        fmin, fmax = 2 / baseline, 480
+    if baseline > 0:
+        # Define frequency grid using largest LC time baseline
+        if doLongPeriod:
+            fmin, fmax = 2 / baseline, 48
+        else:
+            fmin, fmax = 2 / baseline, 480
 
-    df = 1.0 / (samples_per_peak * baseline)
-    nf = int(np.ceil((fmax - fmin) / df))
-    freqs = fmin + df * np.arange(nf)
+        df = 1.0 / (samples_per_peak * baseline)
+        nf = int(np.ceil((fmax - fmin) / df))
+        freqs = fmin + df * np.arange(nf)
 
-    # Define terrestrial frequencies to remove
-    if doRemoveTerrestrial:
-        freqs_to_remove = [
-            [3e-2, 4e-2],
-            [3.95, 4.05],
-            [2.95, 3.05],
-            [1.95, 2.05],
-            [0.95, 1.05],
-            [0.48, 0.52],
-            [0.32, 0.34],
-        ]
-    else:
-        freqs_to_remove = None
+        # Define terrestrial frequencies to remove
+        if doRemoveTerrestrial:
+            freqs_to_remove = [
+                [3e-2, 4e-2],
+                [3.95, 4.05],
+                [2.95, 3.05],
+                [1.95, 2.05],
+                [0.95, 1.05],
+                [0.48, 0.52],
+                [0.32, 0.34],
+            ]
+        else:
+            freqs_to_remove = None
 
-    # Continue with periodsearch/periodfind
-    if doCPU or doGPU:
-        if doCPU and doGPU:
-            raise KeyError('Please set only one of -doCPU or -doGPU.')
-        periods, significances, pdots = periodsearch.find_periods(
-            period_algorithm,
-            tme_collection,
-            freqs,
-            batch_size=period_batch_size,
-            doGPU=doGPU,
-            doCPU=doCPU,
-            doSaveMemory=False,
-            doRemoveTerrestrial=doRemoveTerrestrial,
-            doUsePDot=False,
-            doSingleTimeSegment=False,
-            freqs_to_remove=freqs_to_remove,
-            phase_bins=20,
-            mag_bins=10,
-            doParallel=doParallel,
-            Ncore=Ncore,
+        # Continue with periodsearch/periodfind
+        if doCPU or doGPU:
+            if doCPU and doGPU:
+                raise KeyError('Please set only one of -doCPU or -doGPU.')
+            periods, significances, pdots = periodsearch.find_periods(
+                period_algorithm,
+                tme_collection,
+                freqs,
+                batch_size=period_batch_size,
+                doGPU=doGPU,
+                doCPU=doCPU,
+                doSaveMemory=False,
+                doRemoveTerrestrial=doRemoveTerrestrial,
+                doUsePDot=False,
+                doSingleTimeSegment=False,
+                freqs_to_remove=freqs_to_remove,
+                phase_bins=20,
+                mag_bins=10,
+                doParallel=doParallel,
+                Ncore=Ncore,
+            )
+
+        else:
+            warnings.warn("Skipping period finding; setting all periods to 1.0 d.")
+            # Default periods 1.0 d
+            periods = np.ones(len(tme_collection))
+            significances = np.ones(len(tme_collection))
+            pdots = np.ones(len(tme_collection))
+
+        print('Calculating Fourier stats...')
+        count = 0
+        for idx, _id in enumerate(keep_id_list):
+            count += 1
+            if (idx + 1) % limit == 0:
+                print(f"{count} done")
+            if count == len(keep_id_list):
+                print(f"{count} sources meeting min_n_lc_points requirement done")
+
+            period = periods[idx]
+            significance = significances[idx]
+            pdot = pdots[idx]
+            tt, mm, ee = tme_collection[idx]
+
+            # Calculate Fourier stats
+            (
+                f1_power,
+                f1_BIC,
+                f1_a,
+                f1_b,
+                f1_amp,
+                f1_phi0,
+                f1_relamp1,
+                f1_relphi1,
+                f1_relamp2,
+                f1_relphi2,
+                f1_relamp3,
+                f1_relphi3,
+                f1_relamp4,
+                f1_relphi4,
+            ) = lcstats.calc_fourier_stats(tt, mm, ee, period)
+
+            feature_dict[_id]['f1_power'] = f1_power
+            feature_dict[_id]['f1_BIC'] = f1_BIC
+            feature_dict[_id]['f1_a'] = f1_a
+            feature_dict[_id]['f1_b'] = f1_b
+            feature_dict[_id]['f1_amp'] = f1_amp
+            feature_dict[_id]['f1_phi0'] = f1_phi0
+            feature_dict[_id]['f1_relamp1'] = f1_relamp1
+            feature_dict[_id]['f1_relphi1'] = f1_relphi1
+            feature_dict[_id]['f1_relamp2'] = f1_relamp2
+            feature_dict[_id]['f1_relphi2'] = f1_relphi2
+            feature_dict[_id]['f1_relamp3'] = f1_relamp3
+            feature_dict[_id]['f1_relphi3'] = f1_relphi3
+            feature_dict[_id]['f1_relamp4'] = f1_relamp4
+            feature_dict[_id]['f1_relphi4'] = f1_relphi4
+
+            feature_dict[_id]['period'] = period
+            feature_dict[_id]['significance'] = significance
+            feature_dict[_id]['pdot'] = pdot
+
+        # Get ZTF alert stats
+        alert_stats_dct = alertstats.get_ztf_alert_stats(
+            feature_dict,
+            kowalski_instance=kowalski_instances['kowalski'],
+            radius_arcsec=xmatch_radius_arcsec,
+            limit=limit,
         )
+        for _id in feature_dict.keys():
+            feature_dict[_id]['n_ztf_alerts'] = alert_stats_dct[_id]['n_ztf_alerts']
+            feature_dict[_id]['mean_ztf_alert_braai'] = alert_stats_dct[_id][
+                'mean_ztf_alert_braai'
+            ]
+
+        # Add crossmatches to Gaia, AllWISE and PS1 (by default, see config.yaml)
+        feature_dict = external_xmatch.xmatch(
+            feature_dict,
+            kowalski_instances['gloria'],
+            catalog_info=ext_catalog_info,
+            radius_arcsec=xmatch_radius_arcsec,
+            limit=limit,
+        )
+        feature_df = pd.DataFrame.from_dict(feature_dict, orient='index')
+
+        # Convert various _id datatypes to Int64
+        colnames = [x for x in feature_df.columns]
+        for col in colnames:
+            if '_id' in col:
+                feature_df[col] = feature_df[col].astype("Int64")
+
+        utcnow = datetime.utcnow()
+        end_dt = utcnow.strftime("%Y-%m-%d %H:%M:%S")
+
+        # Add metadata
+        feature_df.attrs['scope_code_version'] = code_version
+        feature_df.attrs['feature_generation_start_dateTime_utc'] = start_dt
+        feature_df.attrs['feature_generation_end_dateTime_utc'] = end_dt
+        feature_df.attrs['ZTF_source_catalog'] = source_catalog
+        feature_df.attrs['ZTF_alerts_catalog'] = alerts_catalog
+        feature_df.attrs['Gaia_catalog'] = gaia_catalog
 
     else:
-        warnings.warn("Skipping period finding; setting all periods to 1.0 d.")
-        # Default periods 1.0 d
-        periods = np.ones(len(tme_collection))
-        significances = np.ones(len(tme_collection))
-        pdots = np.ones(len(tme_collection))
-
-    print('Calculating Fourier stats...')
-    count = 0
-    for idx, _id in enumerate(keep_id_list):
-        count += 1
-        if (idx + 1) % limit == 0:
-            print(f"{count} done")
-        if count == len(keep_id_list):
-            print(f"{count} sources meeting min_n_lc_points requirement done")
-
-        period = periods[idx]
-        significance = significances[idx]
-        pdot = pdots[idx]
-        tt, mm, ee = tme_collection[idx]
-
-        # Calculate Fourier stats
-        (
-            f1_power,
-            f1_BIC,
-            f1_a,
-            f1_b,
-            f1_amp,
-            f1_phi0,
-            f1_relamp1,
-            f1_relphi1,
-            f1_relamp2,
-            f1_relphi2,
-            f1_relamp3,
-            f1_relphi3,
-            f1_relamp4,
-            f1_relphi4,
-        ) = lcstats.calc_fourier_stats(tt, mm, ee, period)
-
-        feature_dict[_id]['f1_power'] = f1_power
-        feature_dict[_id]['f1_BIC'] = f1_BIC
-        feature_dict[_id]['f1_a'] = f1_a
-        feature_dict[_id]['f1_b'] = f1_b
-        feature_dict[_id]['f1_amp'] = f1_amp
-        feature_dict[_id]['f1_phi0'] = f1_phi0
-        feature_dict[_id]['f1_relamp1'] = f1_relamp1
-        feature_dict[_id]['f1_relphi1'] = f1_relphi1
-        feature_dict[_id]['f1_relamp2'] = f1_relamp2
-        feature_dict[_id]['f1_relphi2'] = f1_relphi2
-        feature_dict[_id]['f1_relamp3'] = f1_relamp3
-        feature_dict[_id]['f1_relphi3'] = f1_relphi3
-        feature_dict[_id]['f1_relamp4'] = f1_relamp4
-        feature_dict[_id]['f1_relphi4'] = f1_relphi4
-
-        feature_dict[_id]['period'] = period
-        feature_dict[_id]['significance'] = significance
-        feature_dict[_id]['pdot'] = pdot
-
-    # Get ZTF alert stats
-    alert_stats_dct = alertstats.get_ztf_alert_stats(
-        feature_dict,
-        kowalski_instance=kowalski_instances['kowalski'],
-        radius_arcsec=xmatch_radius_arcsec,
-        limit=limit,
-    )
-    for _id in feature_dict.keys():
-        feature_dict[_id]['n_ztf_alerts'] = alert_stats_dct[_id]['n_ztf_alerts']
-        feature_dict[_id]['mean_ztf_alert_braai'] = alert_stats_dct[_id][
-            'mean_ztf_alert_braai'
-        ]
-
-    # Add crossmatches to Gaia, AllWISE and PS1 (by default, see config.yaml)
-    feature_dict = external_xmatch.xmatch(
-        feature_dict,
-        kowalski_instances['gloria'],
-        catalog_info=ext_catalog_info,
-        radius_arcsec=xmatch_radius_arcsec,
-        limit=limit,
-    )
-    feature_df = pd.DataFrame.from_dict(feature_dict, orient='index')
-
-    # Convert various _id datatypes to Int64
-    colnames = [x for x in feature_df.columns]
-    for col in colnames:
-        if '_id' in col:
-            feature_df[col] = feature_df[col].astype("Int64")
-
-    utcnow = datetime.utcnow()
-    end_dt = utcnow.strftime("%Y-%m-%d %H:%M:%S")
-
-    # Add metadata
-    feature_df.attrs['scope_code_version'] = code_version
-    feature_df.attrs['feature_generation_start_dateTime_utc'] = start_dt
-    feature_df.attrs['feature_generation_end_dateTime_utc'] = end_dt
-    feature_df.attrs['ZTF_source_catalog'] = source_catalog
-    feature_df.attrs['ZTF_alerts_catalog'] = alerts_catalog
-    feature_df.attrs['Gaia_catalog'] = gaia_catalog
+        # If baseline is still zero, then no light curves met the selection criteria
+        # Generate an empty DF instead so this field/ccd/quad is treated as done
+        print('No light curves meet selection criteria.')
+        feature_df = pd.DataFrame()
 
     # Write results
     if not doNotSave:
@@ -570,147 +588,149 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "-source_catalog",
+        "--source_catalog",
         default=source_catalog,
         help="name of source collection on Kowalski",
     )
     parser.add_argument(
-        "-alerts_catalog",
+        "--alerts_catalog",
         default=alerts_catalog,
         help="name of alerts collection on Kowalski",
     )
     parser.add_argument(
-        "-gaia_catalog",
+        "--gaia_catalog",
         default=gaia_catalog,
         help="name of Gaia collection on Kowalski",
     )
     parser.add_argument(
-        "-bright_star_query_radius_arcsec",
+        "--bright_star_query_radius_arcsec",
         type=float,
         default=300.0,
         help="size of cone search radius to search for bright stars",
     )
     parser.add_argument(
-        "-xmatch_radius_arcsec",
+        "--xmatch_radius_arcsec",
         type=float,
         default=2.0,
         help="cone radius for all crossmatches",
     )
     parser.add_argument(
-        "-query_size_limit",
+        "--query_size_limit",
         type=int,
         default=10000,
         help="sources per query limit for large Kowalski queries",
     )
 
     parser.add_argument(
-        "-period_algorithm",
+        "--period_algorithm",
         default='LS',
         help="algorithm in periodsearch.py to use for period-finding",
     )
 
     parser.add_argument(
-        "-period_batch_size",
+        "--period_batch_size",
         type=int,
         default=1,
         help="batch size for GPU-accelerated period algorithms",
     )
     parser.add_argument(
-        "-doCPU",
+        "--doCPU",
         action='store_true',
         default=False,
         help="if set, run period-finding algorithm on CPU",
     )
     parser.add_argument(
-        "-doGPU",
+        "--doGPU",
         action='store_true',
         default=False,
         help="if set, use GPU-accelerated period algorithm",
     )
     parser.add_argument(
-        "-samples_per_peak",
+        "--samples_per_peak",
         default=10,
         type=int,
     )
     parser.add_argument(
-        "-doLongPeriod",
+        "--doLongPeriod",
         action='store_true',
         default=False,
         help="if set, optimize frequency grid for long periods",
     )
     parser.add_argument(
-        "-doRemoveTerrestrial",
+        "--doRemoveTerrestrial",
         action='store_true',
         default=False,
         help="if set, remove terrestrial frequencies from period analysis",
     )
     parser.add_argument(
-        "-doParallel",
+        "--doParallel",
         action="store_true",
         default=False,
         help="If set, parallelize period finding",
     )
     parser.add_argument(
-        "-Ncore",
+        "--Ncore",
         default=8,
         type=int,
         help="number of cores for parallel period finding",
     )
-    # Loop over field/ccd/quad functionality coming soon
-    # parser.add_argument("-doAllFields", action='store_true', default=False, help="if set, run on all fields")
     parser.add_argument(
-        "-field", type=int, default=296, help="if not -doAllFields, ZTF field to run on"
-    )
-    # parser.add_argument("-doAllCCDs", action='store_true', default=False, help="if set, run on all ccds for given field")
-    parser.add_argument(
-        "-ccd", type=int, default=1, help="if not -doAllCCDs, ZTF ccd to run on"
-    )
-    # parser.add_argument("-doAllQuads", action='store_true', default=False, help="if set, run on all quads for specified field/ccds")
-    parser.add_argument(
-        "-quad", type=int, default=1, help="if not -doAllQuads, ZTF field to run on"
+        "--field",
+        type=int,
+        default=296,
+        help="if not -doAllFields, ZTF field to run on",
     )
     parser.add_argument(
-        "-min_n_lc_points",
+        "--ccd", type=int, default=1, help="if not -doAllCCDs, ZTF ccd to run on"
+    )
+    parser.add_argument(
+        "--quad", type=int, default=1, help="if not -doAllQuads, ZTF field to run on"
+    )
+    parser.add_argument(
+        "--min_n_lc_points",
         type=int,
         default=50,
         help="minimum number of unflagged light curve points to run feature generation",
     )
     parser.add_argument(
-        "-min_cadence_minutes",
+        "--min_cadence_minutes",
         type=float,
         default=30.0,
         help="minimum cadence (in minutes) between light curve points. For groups of points closer together than this value, only the first will be kept.",
     )
     parser.add_argument(
-        "-dirname",
+        "--dirname",
         type=str,
         default='generated_features',
-        help="if set, run on all quads for specified field/ccds",
+        help="Directory name for generated features",
     )
     parser.add_argument(
-        "-filename",
+        "--filename",
         type=str,
         default='gen_features',
-        help="if set, run on all quads for specified field/ccds",
+        help="Prefix for generated feature file",
     )
     parser.add_argument(
-        "-doCesium",
+        "--doCesium",
         action='store_true',
         default=False,
         help="if set, use Cesium to generate additional features specified in config",
     )
     parser.add_argument(
-        "-doNotSave",
+        "--doNotSave",
         action='store_true',
         default=False,
         help="if set, do not save features",
     )
     parser.add_argument(
-        "-stop_early",
+        "--stop_early",
         action='store_true',
         default=False,
         help="if set, stop when number of sources reaches query_size_limit. Helpful for testing on small samples.",
     )
+    parser.add_argument("--doQuadrantFile", action="store_true", default=False)
+    parser.add_argument("--quadrant_file", default="slurm.dat")
+    parser.add_argument("--quadrant_index", default=0, type=int)
 
     args = parser.parse_args()
 
@@ -731,11 +751,8 @@ if __name__ == "__main__":
         doRemoveTerrestrial=args.doRemoveTerrestrial,
         doParallel=args.doParallel,
         Ncore=args.Ncore,
-        # args.doAllFields,
         field=args.field,
-        # args.doAllCCDs,
         ccd=args.ccd,
-        # args.doAllQuads,
         quad=args.quad,
         min_n_lc_points=args.min_n_lc_points,
         min_cadence_minutes=args.min_cadence_minutes,
@@ -744,4 +761,7 @@ if __name__ == "__main__":
         doCesium=args.doCesium,
         doNotSave=args.doNotSave,
         stop_early=args.stop_early,
+        doQuadrantFile=args.doQuadrantFile,
+        quadrant_file=args.quadrant_file,
+        quadrant_index=args.quadrant_index,
     )

--- a/tools/generate_features_job_submission.py
+++ b/tools/generate_features_job_submission.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+import os
+import pathlib
+import time
+import argparse
+import pandas as pd
+import numpy as np
+
+
+BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()
+
+
+def parse_commandline():
+    """
+    Parse the options given on the command-line.
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--dirname",
+        type=str,
+        default='generated_features',
+        help="Directory name for generated features",
+    )
+    parser.add_argument(
+        "--filename",
+        type=str,
+        default='gen_features',
+        help="Prefix for generated feature file",
+    )
+    parser.add_argument(
+        "-f", "--filetype", default="slurm", help="Type of submission file"
+    )
+    parser.add_argument(
+        "--doSubmit",
+        action="store_true",
+        default=False,
+        help="If set, start jobs with limits specified by --max_instances and --wait_time_minutes",
+    )
+    parser.add_argument(
+        "--max_instances",
+        type=int,
+        default=100,
+        help="Max number of instances to run in parallel",
+    )
+    parser.add_argument(
+        "--wait_time_minutes",
+        type=float,
+        default=10.0,
+        help="Time to wait between job status checks",
+    )
+    parser.add_argument(
+        "--doSubmitLoop",
+        action="store_true",
+        default=False,
+        help="If set, loop to initiate instances until out of jobs (hard on Kowalski)",
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def filter_completed(df, resultsDir, filename):
+
+    start_time = time.time()
+
+    tbd = []
+    for ii, (_, row) in enumerate(df.iterrows()):
+
+        field, ccd, quadrant = int(row["field"]), int(row["ccd"]), int(row["quadrant"])
+
+        resultsDir_iter = resultsDir + f"/field_{field}"
+        filename_iter = filename + f"_field_{field}_ccd_{ccd}_quad_{quadrant}"
+        filename_iter += '.parquet'
+        filepath = os.path.join(resultsDir_iter, filename_iter)
+
+        if not os.path.isfile(filepath):
+            tbd.append(ii)
+        else:
+            print(filepath)
+    df = df.iloc[tbd]
+
+    end_time = time.time()
+    print('Checking completed jobs took %.2f seconds' % (end_time - start_time))
+
+    return df
+
+
+def run_job(df, quadrant_index, resultsDir, filename):
+
+    row = df.iloc[quadrant_index]
+    field, ccd, quadrant = int(row["field"]), int(row["ccd"]), int(row["quadrant"])
+
+    resultsDir += f"/field_{field}"
+    filename += f"_field_{field}_ccd_{ccd}_quad_{quadrant}"
+    filename += '.parquet'
+    filepath = os.path.join(resultsDir, filename)
+
+    if not os.path.isfile(filepath):
+        jobstr = jobline.replace("$PBS_ARRAYID", "%d" % row["job_number"])
+        print(jobstr)
+        os.system(jobstr)
+
+
+if __name__ == '__main__':
+    # Parse command line
+    args = parse_commandline()
+
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+
+    filename = args.filename
+    filetype = args.filetype
+    dirname = args.dirname
+    resultsDir = str(BASE_DIR / dirname)
+
+    qsubDir = os.path.join(resultsDir, filetype)
+    if not os.path.isdir(qsubDir):
+        os.makedirs(qsubDir)
+    qsubfile = os.path.join(qsubDir, '%s.sub' % filetype)
+
+    lines = [line.rstrip('\n') for line in open(qsubfile)]
+    jobline = lines[-1]
+    joblineSplit = list(filter(None, jobline.split("algorithm")[-1].split(" ")))
+    algorithm = joblineSplit[0]
+
+    quadrantfile = os.path.join(qsubDir, '%s.dat' % filetype)
+
+    names = ["job_number", "field", "ccd", "quadrant"]
+
+    df_original = pd.read_csv(quadrantfile, header=None, delimiter=' ', names=names)
+    pd.set_option('display.max_columns', None)
+    df = filter_completed(df_original, resultsDir, filename)
+    njobs = len(df)
+    print('%d jobs remaining...' % njobs)
+
+    if args.doSubmit:
+        counter = 0
+        status_njobs = njobs
+        diff_njobs = 0
+        while njobs > 0:
+            # Limit number of parallel jobs to 100 for Kowalski stability
+            if counter < args.max_instances:
+                quadrant_index = np.random.randint(0, njobs, size=1)
+                run_job(df, quadrant_index, resultsDir, filename)
+
+                counter = counter + 1
+                print(counter)
+
+            else:
+                # Wait between status checks
+                time.sleep(args.wait_time_minutes * 60)
+                df = filter_completed(df, resultsDir, filename)
+                njobs = len(df)
+
+                print('%d jobs remaining...' % njobs)
+                diff_njobs = status_njobs - njobs
+                status_njobs = njobs
+                # Decrease counter if jobs have finished
+                counter -= diff_njobs
+
+    elif args.doSubmitLoop:
+        for quadrant_index in range(njobs):
+            run_job(df, quadrant_index, resultsDir, filename)

--- a/tools/generate_features_slurm.py
+++ b/tools/generate_features_slurm.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python
+import argparse
+import pathlib
+import yaml
+import os
+from penquins import Kowalski
+import numpy as np
+
+
+BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()
+
+# setup connection to Kowalski instances
+config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
+with open(config_path) as config_yaml:
+    config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+
+# use token specified as env var (if exists)
+kowalski_token_env = os.environ.get("KOWALSKI_TOKEN")
+kowalski_alt_token_env = os.environ.get("KOWALSKI_ALT_TOKEN")
+if (kowalski_token_env is not None) & (kowalski_alt_token_env is not None):
+    config["kowalski"]["token"] = kowalski_token_env
+    config["kowalski"]["alt_token"] = kowalski_alt_token_env
+
+timeout = config['kowalski']['timeout']
+
+gloria = Kowalski(**config['kowalski'], verbose=False)
+melman = Kowalski(
+    token=config['kowalski']['token'],
+    protocol="https",
+    host="melman.caltech.edu",
+    port=443,
+    timeout=timeout,
+)
+kowalski = Kowalski(
+    token=config['kowalski']['alt_token'],
+    protocol="https",
+    host="kowalski.caltech.edu",
+    port=443,
+    timeout=timeout,
+)
+
+source_catalog = config['kowalski']['collections']['sources']
+alerts_catalog = config['kowalski']['collections']['alerts']
+gaia_catalog = config['kowalski']['collections']['gaia']
+ext_catalog_info = config['feature_generation']['external_catalog_features']
+cesium_feature_list = config['feature_generation']['cesium_features']
+
+kowalski_instances = {'kowalski': kowalski, 'gloria': gloria, 'melman': melman}
+
+
+def check_quads_for_sources(
+    fields: list = np.arange(1, 2001),
+    kowalski_instance_name: str = 'melman',
+    catalog=source_catalog,
+):
+    """
+    Check ZTF field/ccd/quadrant combos for any sources.
+
+    """
+    kowalski_instance = kowalski_instances[kowalski_instance_name]
+
+    has_sources = np.zeros(len(fields), dtype=bool)
+    missing_ccd_quad = np.zeros(len(fields), dtype=bool)
+    field_dct = {}
+    for idx, field in enumerate(fields):
+        print('Running field %d' % field)
+        except_count = 0
+        # Run minimal query to determine if sources exist in field
+        q = {
+            "query_type": "find",
+            "query": {
+                "catalog": catalog,
+                "filter": {
+                    'field': {'$eq': int(field)},
+                },
+                "projection": {"_id": 1},
+            },
+            "kwargs": {"limit": 1},
+        }
+        rsp = kowalski_instance.query(q)
+        data = rsp['data']
+
+        if len(data) > 0:
+            has_sources[idx] = True
+        else:
+            continue
+
+        if has_sources[idx]:
+            print(f'Field {field} has sources...')
+            field_dct[field] = {}
+            for ccd in range(1, 17):
+                quads = []
+                for quadrant in range(1, 5):
+
+                    # Another minimal query for each ccd/quad combo
+                    q = {
+                        "query_type": "find",
+                        "query": {
+                            "catalog": catalog,
+                            "filter": {
+                                'field': {'$eq': int(field)},
+                                'ccd': {'$eq': int(ccd)},
+                                'quad': {'$eq': int(quadrant)},
+                            },
+                            "projection": {"_id": 1},
+                        },
+                        "kwargs": {"limit": 1},
+                    }
+                    rsp = kowalski_instance.query(q)
+                    data = rsp['data']
+
+                    if len(data) > 0:
+                        quads += [quadrant]
+                    else:
+                        except_count += 1
+
+                if len(quads) > 0:
+                    field_dct[field].update({ccd: quads})
+
+        print(f"{64 - except_count} ccd/quad combos")
+        if except_count > 0:
+            missing_ccd_quad[idx] = True
+
+    print(f"Sources found in {np.sum(has_sources)} fields.")
+
+    return field_dct, has_sources, missing_ccd_quad
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--source_catalog",
+        default=source_catalog,
+        help="name of source collection on Kowalski",
+    )
+    parser.add_argument(
+        "--alerts_catalog",
+        default=alerts_catalog,
+        help="name of alerts collection on Kowalski",
+    )
+    parser.add_argument(
+        "--gaia_catalog",
+        default=gaia_catalog,
+        help="name of Gaia collection on Kowalski",
+    )
+    parser.add_argument(
+        "--bright_star_query_radius_arcsec",
+        type=float,
+        default=300.0,
+        help="size of cone search radius to search for bright stars",
+    )
+    parser.add_argument(
+        "--xmatch_radius_arcsec",
+        type=float,
+        default=2.0,
+        help="cone radius for all crossmatches",
+    )
+    parser.add_argument(
+        "--query_size_limit",
+        type=int,
+        default=10000,
+        help="sources per query limit for large Kowalski queries",
+    )
+
+    parser.add_argument(
+        "--period_algorithm",
+        default='LS',
+        help="algorithm in periodsearch.py to use for period-finding",
+    )
+
+    parser.add_argument(
+        "--period_batch_size",
+        type=int,
+        default=1,
+        help="batch size for GPU-accelerated period algorithms",
+    )
+    parser.add_argument(
+        "--doCPU",
+        action='store_true',
+        default=False,
+        help="if set, run period-finding algorithm on CPU",
+    )
+    parser.add_argument(
+        "--doGPU",
+        action='store_true',
+        default=False,
+        help="if set, use GPU-accelerated period algorithm",
+    )
+    parser.add_argument(
+        "--samples_per_peak",
+        default=10,
+        type=int,
+    )
+    parser.add_argument(
+        "--doLongPeriod",
+        action='store_true',
+        default=False,
+        help="if set, optimize frequency grid for long periods",
+    )
+    parser.add_argument(
+        "--doRemoveTerrestrial",
+        action='store_true',
+        default=False,
+        help="if set, remove terrestrial frequencies from period analysis",
+    )
+    parser.add_argument(
+        "--doParallel",
+        action="store_true",
+        default=False,
+        help="If set, parallelize period finding",
+    )
+    parser.add_argument(
+        "--Ncore",
+        default=8,
+        type=int,
+        help="number of cores for parallel period finding",
+    )
+    parser.add_argument(
+        "--field",
+        type=int,
+        default=296,
+        help="if not -doAllFields, ZTF field to run on",
+    )
+    parser.add_argument(
+        "--ccd", type=int, default=1, help="if not -doAllCCDs, ZTF ccd to run on"
+    )
+    parser.add_argument(
+        "--quad", type=int, default=1, help="if not -doAllQuads, ZTF field to run on"
+    )
+    parser.add_argument(
+        "--min_n_lc_points",
+        type=int,
+        default=50,
+        help="minimum number of unflagged light curve points to run feature generation",
+    )
+    parser.add_argument(
+        "--min_cadence_minutes",
+        type=float,
+        default=30.0,
+        help="minimum cadence (in minutes) between light curve points. For groups of points closer together than this value, only the first will be kept.",
+    )
+    parser.add_argument(
+        "--dirname",
+        type=str,
+        default='generated_features',
+        help="Directory name for generated features",
+    )
+    parser.add_argument(
+        "--filename",
+        type=str,
+        default='gen_features',
+        help="if set, run on all quads for specified field/ccds",
+    )
+    parser.add_argument(
+        "--doCesium",
+        action='store_true',
+        default=False,
+        help="if set, use Cesium to generate additional features specified in config",
+    )
+    parser.add_argument(
+        "--doNotSave",
+        action='store_true',
+        default=False,
+        help="if set, do not save features",
+    )
+    parser.add_argument(
+        "--stop_early",
+        action='store_true',
+        default=False,
+        help="if set, stop when number of sources reaches query_size_limit. Helpful for testing on small samples.",
+    )
+    parser.add_argument(
+        "--job_name",
+        type=str,
+        default='generate_features',
+        help="job name",
+    )
+    parser.add_argument(
+        "--queue_type",
+        type=str,
+        default='p100',
+        help="p100 or k80",
+    )
+    parser.add_argument(
+        "--mail_user",
+        type=str,
+        default='healyb@umn.edu',
+        help="contact email address",
+    )
+    parser.add_argument(
+        "--kowalski_instance_name",
+        type=str,
+        default='melman',
+        help="Name of Kowalski instance containing source collection",
+    )
+    parser.add_argument(
+        "--generateQuadrantFile",
+        action='store_true',
+        default=False,
+        help="if set, generate a list of fields/ccd/quads and job numbers, save to slurm.dat",
+    )
+    parser.add_argument("--doQuadrantFile", action="store_true", default=False)
+    parser.add_argument("--quadrant_file", default="slurm.dat")
+    parser.add_argument("--quadrant_index", default=0, type=int)
+    parser.add_argument(
+        "--max_instances",
+        type=int,
+        default=100,
+        help="Max number of instances to run in parallel",
+    )
+    parser.add_argument(
+        "--wait_time_minutes",
+        type=float,
+        default=10.0,
+        help="Time to wait between job status checks",
+    )
+
+    args = parser.parse_args()
+
+    if not (args.doCPU or args.doGPU):
+        print("--doCPU or --doGPU required")
+        exit(0)
+
+    source_catalog = args.source_catalog
+    alerts_catalog = args.alerts_catalog
+    gaia_catalog = args.gaia_catalog
+    bright_star_query_radius_arcsec = args.bright_star_query_radius_arcsec
+    xmatch_radius_arcsec = args.xmatch_radius_arcsec
+    limit = args.query_size_limit
+    period_algorithm = args.period_algorithm
+    period_batch_size = args.period_batch_size
+    doCPU = args.doCPU
+    doGPU = args.doGPU
+    samples_per_peak = args.samples_per_peak
+    doLongPeriod = args.doLongPeriod
+    doRemoveTerrestrial = args.doRemoveTerrestrial
+    doParallel = args.doParallel
+    Ncore = args.Ncore
+    field = args.field
+    ccd = args.ccd
+    quad = args.quad
+    min_n_lc_points = args.min_n_lc_points
+    min_cadence_minutes = args.min_cadence_minutes
+    dirname = args.dirname
+    filename = args.filename
+    doCesium = args.doCesium
+    doNotSave = args.doNotSave
+    stop_early = args.stop_early
+
+    if args.doCPU:
+        cpu_gpu_flag = "--doCPU"
+    else:
+        cpu_gpu_flag = "--doGPU"
+
+    extra_flags = []
+    if args.doLongPeriod:
+        extra_flags.append("--doLongPeriod")
+    if args.doRemoveTerrestrial:
+        extra_flags.append("--doRemoveTerrestrial")
+    if args.doParallel:
+        extra_flags.append("--doParallel")
+    if args.doCesium:
+        extra_flags.append("--doCesium")
+    if args.doNotSave:
+        extra_flags.append("--doNotSave")
+    if args.stop_early:
+        extra_flags.append("--stop_early")
+    extra_flags = " ".join(extra_flags)
+
+    dirpath = BASE_DIR / dirname
+    os.makedirs(dirpath, exist_ok=True)
+
+    slurmDir = os.path.join(dirpath, 'slurm')
+    if not os.path.isdir(slurmDir):
+        os.makedirs(slurmDir)
+
+    logsDir = os.path.join(dirpath, 'logs')
+    if not os.path.isdir(logsDir):
+        os.makedirs(logsDir)
+
+    quadrantfile = os.path.join(slurmDir, args.quadrant_file)
+    if args.generateQuadrantFile:
+        field_dct, _, _ = check_quads_for_sources(
+            kowalski_instance_name=args.kowalski_instance_name, catalog=source_catalog
+        )
+
+        job_number = 0
+
+        fid = open(quadrantfile, 'w')
+        for field in field_dct.keys():
+            for ccd in field_dct[field].keys():
+                for quad in field_dct[field][ccd]:
+                    fid.write('%d %d %d %d\n' % (job_number, field, ccd, quad))
+                    job_number += 1
+        fid.close()
+
+    fid = open(os.path.join(slurmDir, 'slurm.sub'), 'w')
+    fid.write('#!/bin/bash\n')
+    fid.write(f'#SBATCH --job-name={args.job_name}.job\n')
+    fid.write(f'#SBATCH --output=logs/{args.job_name}_%A_%a.out\n')
+    fid.write(f'#SBATCH --error=logs/{args.job_name}_%A_%a.err\n')
+    fid.write('#SBATCH -p gpu-shared\n')
+    if args.queue_type == "p100":
+        fid.write('#SBATCH --gres=gpu:p100:1 --mem=8GB\n')
+    elif args.queue_type == "k80":
+        fid.write('#SBATCH --gres=gpu:k80:1 --mem=8GB\n')
+    else:
+        print('queue_type must be p100 or k80')
+        exit(0)
+    fid.write('#SBATCH --time=2:00:00\n')
+    fid.write('#SBATCH --mail-type=ALL\n')
+    fid.write(f'#SBATCH --mail-user={args.mail_user}\n')
+    fid.write('#SBATCH -A umn130\n')
+    # Not sure if below line is necessary - commented for now
+    # fid.write('source %s/setup.sh\n' % BASE_DIR)
+    if args.doQuadrantFile:
+        fid.write(
+            '%s/generate_features.py --source_catalog %s --alerts_catalog %s --gaia_catalog %s --bright_star_query_radius_arcsec %s --xmatch_radius_arcsec %s --limit %s --period_algorithm %s --period_batch_size %s --samples_per_peak %s --Ncore %s --min_n_lc_points %s --min_cadence_minutes %s --dirname %s --filename %s --doQuadrantFile --quadrant_file %s --quadrant_index $PBS_ARRAYID %s %s\n'
+            % (
+                BASE_DIR / 'tools',
+                source_catalog,
+                alerts_catalog,
+                gaia_catalog,
+                bright_star_query_radius_arcsec,
+                xmatch_radius_arcsec,
+                limit,
+                period_algorithm,
+                period_batch_size,
+                samples_per_peak,
+                Ncore,
+                min_n_lc_points,
+                min_cadence_minutes,
+                dirname,
+                filename,
+                args.quadrant_file,
+                cpu_gpu_flag,
+                extra_flags,
+            )
+        )
+    else:
+        fid.write(
+            '%s/generate_features.py --source_catalog %s --alerts_catalog %s --gaia_catalog %s --bright_star_query_radius_arcsec %s --xmatch_radius_arcsec %s --limit %s --period_algorithm %s --period_batch_size %s --samples_per_peak %s --Ncore %s --field %s --ccd %s --quad %s --min_n_lc_points %s --min_cadence_minutes %s --dirname %s --filename %s %s %s\n'
+            % (
+                BASE_DIR / 'tools',
+                source_catalog,
+                alerts_catalog,
+                gaia_catalog,
+                bright_star_query_radius_arcsec,
+                xmatch_radius_arcsec,
+                limit,
+                period_algorithm,
+                period_batch_size,
+                samples_per_peak,
+                Ncore,
+                field,
+                ccd,
+                quad,
+                min_n_lc_points,
+                min_cadence_minutes,
+                dirname,
+                filename,
+                cpu_gpu_flag,
+                extra_flags,
+            )
+        )
+    fid.close()
+
+    fid = open(os.path.join(slurmDir, 'slurm_submission.sub'), 'w')
+    fid.write('#!/bin/bash\n')
+    fid.write(f'#SBATCH --job-name={args.job_name}.job\n')
+    fid.write(f'#SBATCH --output=logs/{args.job_name}_%A_%a.out\n')
+    fid.write(f'#SBATCH --error=logs/{args.job_name}_%A_%a.err\n')
+    if "HOSTNAME" in os.environ:
+        if "cori" in os.environ["HOSTNAME"]:
+            fid.write('#SBATCH -C gpu -N 1\n')
+            fid.write('#SBATCH -G 1 --mem=8GB\n')
+            fid.write('#SBATCH -A m3619\n')
+    else:
+        fid.write('#SBATCH -p gpu-shared\n')
+        fid.write('#SBATCH -A umn130\n')
+        if args.queue_type == "p100":
+            fid.write('#SBATCH --gres=gpu:p100:1 --mem=8GB\n')
+        elif args.queue_type == "k80":
+            fid.write('#SBATCH --gres=gpu:k80:1 --mem=8GB\n')
+        else:
+            print('queue_type must be p100 or k80')
+            exit(0)
+    fid.write('#SBATCH --time=2:00:00\n')
+    fid.write('#SBATCH --mail-type=ALL\n')
+    fid.write(f'#SBATCH --mail-user={args.mail_user}\n')
+    fid.write('module purge\n')
+    if "HOSTNAME" in os.environ:
+        if "cori" in os.environ["HOSTNAME"]:
+            fid.write('module load esslurm\n')
+            fid.write('module unload PrgEnv-intel\n')
+            fid.write('module load PrgEnv-gnu\n')
+            fid.write('module load cuda/10.1.243\n')
+    # Not sure if below line is necessary - commented for now
+    # fid.write('source %s/setup.sh\n' % BASE_DIR)
+    fid.write(
+        f'%s/{args.job_name}_job_submission.py --outputDir %s --filename %s --doSubmit --max_instances %s --wait_time_minutes %s\n'
+        % (
+            BASE_DIR / 'tools',
+            dirpath,
+            filename,
+            args.max_instances,
+            args.wait_time_minutes,
+        )
+    )
+    fid.close()


### PR DESCRIPTION
This PR adds code to generate slurm scripts to run scope feature generation in parallel on HPC resources. Changes include:
- `generate_features.py` (modified):
  - Syntax update: all keywords now begin with `--` instead of `-`
  - New check for cases where no light curves pass selection criteria
  - New keywords have been added: `--doQuadrantFile`, `--quadrant_file` and `--quadrant_index` allow the field/ccd/quadrant to be specified using a generated `slurm.dat` file (described below)

- `generate_features_slurm.py` (new):
  -  Optionally checks ZTF fields/ccd/quadrants for sources
  - Maps each field/ccd/quadrant combo with sources to a quadrant index and saves a `slurm.dat` file
  - Saves `slurm.sub` file with `SBATCH` commands and a call to `generate_features.py`. This call includes `--quadrant_index $PBS_ARRAYID`, which gets replaced with the appropriate index for each run
  - Saves `slurm_submission.sub` with `SBATCH` commands and a call to `generate_features_job_submission.py` (see below)

- `generate_features_job_submission.py` (new):
  - Calls multiple runs of `generate_features.py` for different quadrant indices
  - By default, caps number of runs at 100 and checks if any jobs are completed every 10 minutes
  - Initiates new jobs until all are completed 