### PR TITLE
Impute features when using get_features.py

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -95,7 +95,7 @@ If `--pre_trained_group_name` is specified and the `--train_all` keyword is set,
 * The commands for inference of the field `<field_number>` (in order)
   ```
   ./tools/get_quad_ids.py --field=<field_number> --whole-field
-  ./tools/get_features.py --field=<field_number> --whole-field
+  ./tools/get_features.py --field=<field_number> --whole-field --impute-missing-features
   ./get_all_preds.sh <field_number>
   ```
 * Creates a single `.csv` file containing all ids of the field in the rows and inference scores for different classes across the columns.

--- a/scope/utils.py
+++ b/scope/utils.py
@@ -757,6 +757,8 @@ class Dataset(object):
         if self.verbose:
             log(self.df_ds[list(features)].describe())
 
+        # Last-chance imputation - this should have happened by now, but the messages will still print.
+        # If no missing features, the process runs quickly.
         self.df_ds = impute_features(self.df_ds, self_impute=True)
 
         dmdt = []

--- a/scope/utils.py
+++ b/scope/utils.py
@@ -598,6 +598,28 @@ def impute_features(
     for feat in feature_list_regression:
         features_df[feat] = imputed_feats[feat]
 
+    # After imputation, drop rows containing NaN features with no imputation strategy
+    # (Ensures no subsequent errors due to these missing values)
+    feature_list_impute_none = [
+        x
+        for x in config['features']['ontological']
+        if (
+            config['features']['ontological'][x]['include']
+            and config['features']['ontological'][x]['impute_strategy']
+            in ['none', 'None', 'NONE']
+        )
+    ]
+
+    orig_len = len(features_df)
+    features_df = features_df.dropna(subset=feature_list_impute_none).reset_index(
+        drop=True
+    )
+    new_len = len(features_df)
+    print()
+    print(
+        f'Dropped {orig_len - new_len} rows containing missing features with no imputation strategy.'
+    )
+
     return features_df
 
 

--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -54,7 +54,7 @@ def get_features_loop(
     limit_per_query: int = 1000,
     max_sources: int = 100000,
     impute_missing_features: bool = False,
-    self_impute: bool = False,
+    self_impute: bool = True,
     restart: bool = True,
     write_csv: bool = False,
     projection: dict = {},
@@ -144,7 +144,7 @@ def get_features(
     verbose: bool = False,
     limit_per_query: int = 1000,
     impute_missing_features: bool = False,
-    self_impute: bool = False,
+    self_impute: bool = True,
     projection: dict = {},
 ):
     '''
@@ -286,7 +286,7 @@ def run(**kwargs):
     column_list = kwargs.get("column_list", None)
     suffix = kwargs.get("suffix", None)
     impute_missing_features = kwargs.get("impute_missing_features", False)
-    self_impute = kwargs.get("self_impute", False)
+    self_impute = kwargs.get("self_impute", True)
 
     projection = {}
     if column_list is not None:

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -136,6 +136,7 @@ def clean_data(
                 missing_dict[id.astype(str)] += [feature]  # add feature to dict
 
     # impute missing values as specified in config
+    # (Should already be complete to save time here)
     features_df = impute_features(features_df, self_impute=True)
 
     if flag_ids:

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import argparse
+import pathlib
+import yaml
 import pandas as pd
 import scope
 from scope.fritz import api
@@ -14,6 +16,12 @@ from scope.utils import impute_features
 
 NUM_PER_PAGE = 500
 CHECKPOINT_NUM = 500
+
+config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
+with open(config_path) as config_yaml:
+    config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+
+features_catalog = config['kowalski']['collections']['features']
 
 
 def organize_source_data(src: pd.DataFrame):
@@ -644,7 +652,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-features_catalog",
         type=str,
-        default='ZTF_source_features_DR5',
+        default=features_catalog,
         help="catalog of features on Kowalski",
     )
 


### PR DESCRIPTION
This PR adds the option to impute features when calling `get_features.py` using the strategies listed in the config. By using this new option, the user can both query features from Kowalski and impute missing features at the same time.

After imputation, the code drops rows that still have missing features if they have `include: True` in the config. That is, if there is no imputation strategy for a missing feature but that feature is included in training/inference, the row will be dropped to avoid downstream errors. For our current training set with ~180,000 light curves, only one source gets dropped.

This PR (along with #248) resolve #235 and #236 by minimizing the amount of imputation performed before training and inference. 