### PR TITLE
Enable get_features.py loop for multiple ccd/quadrants

### DIFF
--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -231,9 +231,9 @@ def run(**kwargs):
     field: int
         Field number.
     ccd_range: int, list
-        CCD range, single int or list of two ints between 1 and 16 (default range is [1,16])
+        CCD range; single int or list of two ints between 1 and 16 (default range is [1,16])
     quad_range: int, list
-        Quadrant range, single int or list of two ints between 1 and 4 (default range is [1,4])
+        Quadrant range; single int or list of two ints between 1 and 4 (default range is [1,4])
     limit_per_query: int
         Number of sources to query at a time.
     max_sources: int

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -410,14 +410,14 @@ if __name__ == "__main__":
         type=int,
         nargs='+',
         default=DEFAULT_CCD_RANGE,
-        help="ccd range, single int or list of two ints between 1 and 16 (default range is [1,16])",
+        help="ccd range; single int or list of two ints between 1 and 16 (default range is [1,16])",
     )
     parser.add_argument(
         "--quad-range",
         type=int,
         nargs='+',
         default=DEFAULT_QUAD_RANGE,
-        help="quad range, single int or list of two ints between 1 and 4 (default range is [1,4])",
+        help="quad range; single int or list of two ints between 1 and 4 (default range is [1,4])",
     )
     parser.add_argument(
         "--minobs",

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -383,10 +383,6 @@ if __name__ == "__main__":
     DEFAULT_SKIP = 0
     DEFAULT_VERBOSE = 2
 
-    # pass Fritz token through secrets.json or as a command line argument
-    with open(os.path.join(BASE_DIR, 'secrets.json'), 'r') as f:
-        secrets = json.load(f)
-
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--catalog",
@@ -406,29 +402,22 @@ if __name__ == "__main__":
         default=None,
         help="relative directory path to save output files to",
     )
-
     parser.add_argument(
         "--field", type=int, default=DEFAULT_FIELD, help="field number (default 301)"
-    )
-    parser.add_argument(
-        "--ccd", type=int, default=DEFAULT_CCD, help="ccd number (default 4)"
-    )
-    parser.add_argument(
-        "--quad", type=int, default=DEFAULT_QUAD, help="quad number (default 3)"
     )
     parser.add_argument(
         "--ccd-range",
         type=int,
         nargs='+',
         default=DEFAULT_CCD_RANGE,
-        help="ccd range, two ints between 1 and 16 (default range is [1,16])",
+        help="ccd range, single int or list of two ints between 1 and 16 (default range is [1,16])",
     )
     parser.add_argument(
         "--quad-range",
         type=int,
         nargs='+',
         default=DEFAULT_QUAD_RANGE,
-        help="quad range, two ints between 1 and 4 (default range is [1,4])",
+        help="quad range, single int or list of two ints between 1 and 4 (default range is [1,4])",
     )
     parser.add_argument(
         "--minobs",
@@ -478,9 +467,13 @@ if __name__ == "__main__":
 
     if (args.multi_quads) | (args.whole_field):
         if args.whole_field:
-            print('Saving single file for entire field across ccd/quadrant range.')
+            print(
+                f'Saving single file for entire field ({args.field}) across ccd/quadrant range.'
+            )
         else:
-            print('Saving multiple files for each ccd/quadrant pair.')
+            print(
+                f'Saving multiple files for ccd/quadrant pairs in range {args.ccd_range}, {args.quad_range}.'
+            )
         get_ids_loop(
             get_field_ids,
             catalog=args.catalog,
@@ -497,15 +490,25 @@ if __name__ == "__main__":
         )
 
     else:
+        # Handle different types of input for ccd/quad_range
+        if type(args.ccd_range) == list:
+            ccd = args.ccd_range[0]
+        else:
+            ccd = args.ccd_range
+        if type(args.quad_range) == list:
+            quad = args.quad_range[0]
+        else:
+            quad = args.quad_range
         print(
-            f'Saving up to {args.limit} results for single ccd/quadrant pair, skipping {args.skip} rows.'
+            f'Saving up to {args.limit} results for single ccd/quadrant pair ({ccd},{quad}), skipping {args.skip} rows...'
         )
+
         data = get_field_ids(
             catalog=args.catalog,
             kowalski_instance=kowalski_instance,
             field=args.field,
-            ccd=args.ccd,
-            quad=args.quad,
+            ccd=ccd,
+            quad=quad,
             minobs=args.minobs,
             skip=args.skip,
             limit=args.limit,


### PR DESCRIPTION
This PR enables `get_features.py` to get features for multiple ccd/quadrant combinations. Previously it could either cover all of a field's sources or only a single ccd/quad combo. This PR also simplifies the ccd/quad arguments for `get_quad_ids.py`.