### PR TITLE
Update inputs for doc deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,8 +56,8 @@ jobs:
       if: github.event_name == 'push' && github.repository_owner == 'ZwickyTransientFacility'
       uses: JamesIves/github-pages-deploy-action@releases/v4
       with:
-        FOLDER: doc/_build/html
-        REPOSITORY_NAME: ZwickyTransientFacility/scope-docs
-        BRANCH: master
-        SINGLE_COMMIT: true
-        SSH: true
+        folder: doc/_build/html
+        repository-name: ZwickyTransientFacility/scope-docs
+        branch: master
+        single-commit: true
+        ssh-key: true


### PR DESCRIPTION
This PR attempts to fix docs deployment upon push, which seems to not have occurred since last week despite passing tests. This is likely due to the updated version of `JamesIves/github-pages-deploy-action` from `v3` to `v4`. There is a log warning at the beginning of the `Deploy docs` step stating:

`Warning: Unexpected input(s) 'REPOSITORY_NAME', 'SINGLE_COMMIT', 'SSH', valid inputs are ['ssh-key', 'token', 'branch', 'folder', 'target-folder', 'commit-message', 'clean', 'clean-exclude', 'dry-run', 'force', 'git-config-name', 'git-config-email', 'repository-name', 'tag', 'single-commit', 'silent']`

Thus, this PR changes the existing input names to those on the list of valid inputs.
