### PR TITLE
Change submodule links to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "periodfind"]
 	path = periodfind
-	url = git@github.com:ejaszewski/periodfind.git
+	url = https://github.com/ejaszewski/periodfind.git
 [submodule "scope-phenomenology"]
 	path = scope-phenomenology
-	url = git@github.com:bfhealy/scope-phenomenology.git
+	url = https://github.com/bfhealy/scope-phenomenology.git


### PR DESCRIPTION
This PR changes scope's submodule links from ssh to https. This is to avoid ssh-related errors when cloning scope to an HPC cluster.