### PR TITLE
Add GCE submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "scope-phenomenology"]
 	path = scope-phenomenology
 	url = https://github.com/bfhealy/scope-phenomenology.git
+[submodule "gce"]
+	path = gce
+	url = https://github.com/mikekatz04/gce.git


### PR DESCRIPTION
This PR adds [GCE](https://github.com/mikekatz04/gce.git) as a submodule of scope. GCE cannot currently be pip-installed, and it is needed to run the CUDA-accelerated GCE algorithms in `periodsearch.py`.