### PR TITLE
WIP: add requirements for running feature generation on HPC cluster

### DIFF
--- a/requirements-hpc.txt
+++ b/requirements-hpc.txt
@@ -1,2 +1,2 @@
+cupy-cuda110 # version number depends on your cluster's CUDA version, default is 11.0
 cuvarbase
-cupy-cuda110 #version number depends on your cluster's CUDA version, default is 11.0

--- a/requirements-hpc.txt
+++ b/requirements-hpc.txt
@@ -1,0 +1,2 @@
+cuvarbase
+cupy-cuda110 #version number depends on your cluster's CUDA version, default is 11.0


### PR DESCRIPTION
This PR adds a `requirements-hpc.txt` file that contains additional requirements to install when running scope feature generation on an HPC cluster.