### PR TITLE
Replace periodsearch error with warning when significance is nan

### DIFF
--- a/tools/featureGeneration/periodsearch.py
+++ b/tools/featureGeneration/periodsearch.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scope import utils
 import fast_histogram
+import warnings
 
 
 def find_periods(
@@ -346,7 +347,7 @@ def find_periods(
 
             for ii, stat in enumerate(data_out):
                 if np.isnan(stat.significance):
-                    raise ValueError(
+                    warnings.warn(
                         "Oops... significance  is nan... something went wrong"
                     )
 
@@ -470,7 +471,7 @@ def find_periods(
                     period = periods[np.argmax(stat.data)]
 
                 if np.isnan(significance):
-                    raise ValueError(
+                    warnings.warn(
                         "Oops... significance  is nan... something went wrong"
                     )
 


### PR DESCRIPTION
This PR modifies the behavior of `periodsearch.py` to issue a warning instead of raising an error when a source's period significance is `nan`. The error is occasionally raised for the `EAOV` algorithm in `periodfind`. While this change is not a permanent solution, it allows the feature generation script for a field/ccd/quad to continue.

We could additionally yield a `nan` period for sources where the AOV significance is `nan` - our downstream `lcstats.py` code should be able to handle that by returning `nan` for the Fourier features dependent on that period. Currently a finite period is returned even when the significance is `nan`.