### PR TITLE
Revise build.sh for pyaov

### DIFF
--- a/tools/featureGeneration/pyaov/build.sh
+++ b/tools/featureGeneration/pyaov/build.sh
@@ -1,2 +1,3 @@
-# Modify path as appopriate for your conda installer and environment name
-~/miniforge3/envs/scope-env/bin/f2py3 -m aov -c aovconst.f90 aovsub.f90 aov.f90
+# Move the file created by this script to your environment's site-packages directory
+# e.g. $HOME/miniforge3/envs/scope-env/lib/python3.10/site-packages/.
+python -m numpy.f2py -m aov -c aovconst.f90 aovsub.f90 aov.f90


### PR DESCRIPTION
This PR revises the build script for pyaov to be compatible with the basic installation of scope dependencies (f2py is included with numpy).