### PR TITLE
Parallelize Kowalski queries

### DIFF
--- a/tools/featureGeneration/external_xmatch.py
+++ b/tools/featureGeneration/external_xmatch.py
@@ -108,11 +108,9 @@ def xmatch(
 
     id_dct_external = id_dct.copy()
     print('Iterating through results and assigning xmatch features to sources...')
-    print(len(ext_results_dct))
     for catalog in catalog_info.keys():
         cat_results = ext_results_dct[catalog]
-        print(len(cat_results))
-        print(cat_results.keys())
+
         for id in id_dct_external.keys():
             ext_values = cat_results[str(id)]
 

--- a/tools/featureGeneration/external_xmatch.py
+++ b/tools/featureGeneration/external_xmatch.py
@@ -1,6 +1,7 @@
 import numpy as np
 from penquins import Kowalski
 from astropy.coordinates import SkyCoord
+from scope.utils import split_dict
 
 
 def xmatch(
@@ -9,6 +10,7 @@ def xmatch(
     catalog_info: dict,
     radius_arcsec: float = 2.0,
     limit: int = 10000,
+    Ncore: int = 1,
 ):
     """
     Batch cross-match external catalogs by position
@@ -21,6 +23,7 @@ def xmatch(
 
     :return id_dct_external: id_dct updated with external xmatch values
     """
+    limit *= Ncore
 
     n_sources = len(id_dct)
     if n_sources % limit != 0:
@@ -28,6 +31,8 @@ def xmatch(
     else:
         n_iterations = n_sources // limit
     ext_results_dct = {}
+    for c in catalog_info.keys():
+        ext_results_dct[c] = {}
 
     print('Querying crossmatch catalogs in batches...')
     for i in range(0, n_iterations):
@@ -42,6 +47,7 @@ def xmatch(
 
         # Need to add 180 -> no negative RAs
         radec_geojson[0, :] += 180.0
+        radec_dict = dict(zip(id_slice, radec_geojson.transpose().tolist()))
 
         # Store desired external features for later
         cat_projection_names = {}
@@ -56,29 +62,57 @@ def xmatch(
             for x in catalog_info.keys()
         ]
 
-        # Get external catalog data
-        query = {
-            "query_type": "cone_search",
-            "query": {
-                "object_coordinates": {
-                    "radec": dict(zip(id_slice, radec_geojson.transpose().tolist())),
-                    "cone_search_radius": radius_arcsec,
-                    "cone_search_unit": 'arcsec',
-                },
-                "catalogs": catalog_info,
-                "filter": {},
-            },
-        }
-        q = kowalski_instance.query(query)
+        if Ncore > 1:
+            # Split dictionary for parallel querying
+            radec_split_list = [lst for lst in split_dict(radec_dict, Ncore)]
 
-        ext_results = q['data']
-        ext_results_dct.update(ext_results)
+            queries = [
+                {
+                    "query_type": "cone_search",
+                    "query": {
+                        "object_coordinates": {
+                            "radec": dct,
+                            "cone_search_radius": radius_arcsec,
+                            "cone_search_unit": 'arcsec',
+                        },
+                        "catalogs": catalog_info,
+                        "filter": {},
+                    },
+                }
+                for dct in radec_split_list
+            ]
+            q = kowalski_instance.batch_query(queries, n_treads=Ncore)
+            for batch_result in q:
+                ext_results = batch_result['data']
+                for c in catalog_info.keys():
+                    ext_results_dct[c].update(ext_results[c])
+
+        else:
+            # Get external catalog data
+            query = {
+                "query_type": "cone_search",
+                "query": {
+                    "object_coordinates": {
+                        "radec": radec_dict,
+                        "cone_search_radius": radius_arcsec,
+                        "cone_search_unit": 'arcsec',
+                    },
+                    "catalogs": catalog_info,
+                    "filter": {},
+                },
+            }
+            q = kowalski_instance.query(query)
+
+            ext_results = q['data']
+            ext_results_dct.update(ext_results)
 
     id_dct_external = id_dct.copy()
     print('Iterating through results and assigning xmatch features to sources...')
+    print(len(ext_results_dct))
     for catalog in catalog_info.keys():
         cat_results = ext_results_dct[catalog]
-
+        print(len(cat_results))
+        print(cat_results.keys())
         for id in id_dct_external.keys():
             ext_values = cat_results[str(id)]
 

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -96,6 +96,8 @@ def drop_close_bright_stars(
     ids = [x for x in id_dct]
     id_dct_keep = id_dct.copy()
 
+    limit *= Ncore
+
     n_sources = len(id_dct)
     if n_sources % limit != 0:
         n_iterations = n_sources // limit + 1
@@ -349,6 +351,7 @@ def generate_features(
         ids=[x for x in feature_gen_source_list.keys()],
         catalog=source_catalog,
         limit_per_query=limit,
+        Ncore=Ncore,
     )
 
     feature_dict = feature_gen_source_list.copy()
@@ -633,6 +636,7 @@ def generate_features(
             kowalski_instance=kowalski_instances['kowalski'],
             radius_arcsec=xmatch_radius_arcsec,
             limit=limit,
+            Ncore=Ncore,
         )
         for _id in feature_dict.keys():
             feature_dict[_id]['n_ztf_alerts'] = alert_stats_dct[_id]['n_ztf_alerts']
@@ -647,6 +651,7 @@ def generate_features(
             catalog_info=ext_catalog_info,
             radius_arcsec=xmatch_radius_arcsec,
             limit=limit,
+            Ncore=Ncore,
         )
         feature_df = pd.DataFrame.from_dict(feature_dict, orient='index')
 


### PR DESCRIPTION
This PR enables parallelization of Kowalski queries for ZTF light curves, alert stats and external catalogs.