### PR TITLE
Sort light curves to be monotonically increasing in time

### DIFF
--- a/scope/utils.py
+++ b/scope/utils.py
@@ -725,6 +725,15 @@ def split_dict(d, n):
         }
 
 
+def sort_lightcurve(t, m, e):
+    sort_indices = np.argsort(t)
+    t = t[sort_indices]
+    m = m[sort_indices]
+    e = e[sort_indices]
+
+    return t, m, e
+
+
 """ Datasets """
 
 

--- a/scope/utils.py
+++ b/scope/utils.py
@@ -13,6 +13,11 @@ __all__ = [
     "read_parquet",
     "write_parquet",
     "impute_features",
+    "removeHighCadence",
+    "TychoBVfromGaia",
+    "exclude_radius",
+    "split_dict",
+    "sort_lightcurve",
 ]
 
 from astropy.io import fits

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -12,6 +12,7 @@ from scope.utils import (
     removeHighCadence,
     write_parquet,
     split_dict,
+    sort_lightcurve,
 )
 import numpy as np
 from penquins import Kowalski
@@ -375,6 +376,9 @@ def generate_features(
         try:
             tme_arr = np.array(tme)
             t, m, e = tme_arr.transpose()
+
+            # Ensure light curves are monotonically increasing in time
+            t, m, e = sort_lightcurve(t, m, e)
 
             # Remove all but the first of each group of high-cadence points
             tt, mm, ee = removeHighCadence(t, m, e, cadence_minutes=min_cadence_minutes)


### PR DESCRIPTION
This PR sorts each light curve to be monotonically increasing in time before generating features. Multiple feature generation algorithms, including `removeHighCadence()` and `compute_dmdt()`, rely on this sorting to produce results consistent with previous generated features.