### PR TITLE
Streamline query/analysis of nearby sources in Gaia

### DIFF
--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -86,8 +86,6 @@ def drop_close_bright_stars(
         Default is 300 corresponding with approximate maximum from A. Drake's exclusion radius (float)
     :param xmatch_radius_arcsec: size of cone within which to match a queried source with an input source.
         If any sources from the query fall within this cone, the closest one will be matched to the input source and dropped from further bright-star considerations (float)
-    :param limit: batch size of kowalski_instance queries (int)
-    :param Ncore: number of cores for parallel querying (int)
 
     :return id_dct_keep: dictionary containing subset of input sources far enough away from bright stars
     """
@@ -110,8 +108,6 @@ def drop_close_bright_stars(
     max_cone_radius = np.max([max_dec - ctr_dec, max_ra - ctr_ra]) * 3600 * np.sqrt(2)
 
     id_dct_keep = id_dct.copy()
-
-    limit *= Ncore
 
     gaia_results_dct = {}
 
@@ -149,7 +145,6 @@ def drop_close_bright_stars(
     print('Identifying sources too close to bright stars...')
 
     # Loop over each id to compare with query results
-    count = 0
     query_result = np.array(gaia_results_dct['quad'])
 
     if len(query_result) > 0:
@@ -174,12 +169,6 @@ def drop_close_bright_stars(
             single_result = query_result.copy()
 
             Coords = np.copy(Query_Coords)
-
-            count += 1
-            if count % limit == 0:
-                print(f"{count} done")
-            if count == len(ids):
-                print(f"{count} done")
 
             val = id_dct[id]
             ra_geojson, dec_geojson = val['radec_geojson']['coordinates']
@@ -333,7 +322,6 @@ def generate_features(
         field, ccd, quad = int(row["field"]), int(row["ccd"]), int(row["quadrant"])
 
     print(f'Running field {field}, CCD {ccd}, Quadrant {quad}...')
-    limit *= Ncore
 
     print('Getting IDs...')
     _, lst = get_ids_loop(

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -140,7 +140,7 @@ def drop_close_bright_stars(
     q = kowalski_instance.query(query)
 
     gaia_results = q.get('data')
-    gaia_results_dct.update(gaia_results['Gaia_EDR3'])
+    gaia_results_dct.update(gaia_results[catalog])
 
     print('Identifying sources too close to bright stars...')
 
@@ -173,7 +173,7 @@ def drop_close_bright_stars(
             val = id_dct[id]
             ra_geojson, dec_geojson = val['radec_geojson']['coordinates']
 
-            # Compute separations in radians, convert to arcsec
+            # Compute separations in radians and convert, using 1 rad = 206265 arcsec
             # ~10x faster than SkyCoord.separation() if lon/lat is calculated out of loop
             all_separations = angular_separation(lon1[i], lat1[i], lon2, lat2) * 206265
             within_range = all_separations < query_radius_arcsec

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -184,6 +184,7 @@ def get_cone_ids(
     max_distance: float = 2.0,
     distance_units: str = "arcsec",
     limit_per_query: int = 1000,
+    get_coords: bool = False,
 ) -> pd.DataFrame:
     """Cone search ZTF ID for a set of given positions
 
@@ -195,6 +196,7 @@ def get_cone_ids(
     :param max_distance: float
     :param distance_units: arcsec | arcmin | deg | rad
     :param limit_per_query: max number of sources in a query (int)
+    :param get_coords: flag to get radec_geojson coordinates from Kowalski (bool)
 
     :return: DataFrame with ZTF ids paired with input obj_ids
     """
@@ -218,6 +220,10 @@ def get_cone_ids(
 
         radec = [(selected_ra[i], selected_dec[i]) for i in range(len(selected_obj_id))]
 
+        projection = {"_id": 1}
+        if get_coords:
+            projection.update({"coordinates.radec_geojson.coordinates": 1})
+
         query = {
             "query_type": "cone_search",
             "query": {
@@ -229,9 +235,7 @@ def get_cone_ids(
                 "catalogs": {
                     catalog: {
                         "filter": {},
-                        "projection": {
-                            "_id": 1,
-                        },
+                        "projection": projection,
                     }
                 },
             },


### PR DESCRIPTION
This PR reduces the amount of time the feature generation script takes to query/identify nearby sources in Gaia that are too close to ZTF sources. Only one Gaia cone search is performed across the entire quadrant (as defined by the most extreme coordinates among sources on the list + a default 300 arcsec cushion).  In addition, a ~10x performance increase is realized by using `astropy.coordinates.angular_separation()` instead of `SkyCoord.separation()` to compute angular separations. This requires that latitudes/longitudes be calculated before looping over ZTF sources.

For the most crowded field among the 20 test fields (488), the entire process now runs in ~4 min, improving from a time of multiple hours. Closes #308