### PR TITLE
Ensure light curves are queried in batches

### DIFF
--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -348,14 +348,15 @@ def generate_features(
     print('Getting lightcurves...')
     # For small source lists, shrink LC query limit until batching occurs
     lc_limit = limit
-    while lc_limit > len(feature_gen_source_list):
-        lc_limit //= 10
+    if Ncore > 1:
+        while lc_limit > len(feature_gen_source_list):
+            lc_limit //= 10
 
     lcs = get_lightcurves_via_ids(
         kowalski_instance=kowalski_instances['melman'],
         ids=[x for x in feature_gen_source_list.keys()],
         catalog=source_catalog,
-        limit_per_query=limit,
+        limit_per_query=lc_limit,
         Ncore=Ncore,
     )
 

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -349,8 +349,7 @@ def generate_features(
     # For small source lists, shrink LC query limit until batching occurs
     lc_limit = limit
     if Ncore > 1:
-        while lc_limit > len(feature_gen_source_list):
-            lc_limit //= 10
+        lc_limit = int(np.ceil(len(feature_gen_source_list) / Ncore))
 
     lcs = get_lightcurves_via_ids(
         kowalski_instance=kowalski_instances['melman'],

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -73,8 +73,6 @@ def drop_close_bright_stars(
     catalog: str = gaia_catalog,
     query_radius_arcsec: float = 300.0,
     xmatch_radius_arcsec: float = 2.0,
-    limit: int = 10000,
-    Ncore: int = 1,
 ):
     """
     Use Gaia to identify and drop sources that are too close to bright stars
@@ -345,11 +343,14 @@ def generate_features(
         catalog=gaia_catalog,
         query_radius_arcsec=bright_star_query_radius_arcsec,
         xmatch_radius_arcsec=xmatch_radius_arcsec,
-        limit=limit,
-        Ncore=Ncore,
     )
 
     print('Getting lightcurves...')
+    # For small source lists, shrink LC query limit until batching occurs
+    lc_limit = limit
+    while lc_limit > len(feature_gen_source_list):
+        lc_limit //= 10
+
     lcs = get_lightcurves_via_ids(
         kowalski_instance=kowalski_instances['melman'],
         ids=[x for x in feature_gen_source_list.keys()],


### PR DESCRIPTION
For multi-core feature generation, this PR decreases the size limit for light curve queries until it is small enough to run batch  queries. Otherwise, the default `query_size_limit` of 10000 sources may be greater than the number of light curves to query.