### PR TITLE
Add bogus field guide, update label abbreviations

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -192,10 +192,10 @@ docs:
       title: Beta Lyrae
     bogus_1:
       coordinates: [328.1595911, 69.6487077]
-      title: Bogus "flaring" from saturation ghosts
+      title: Bogus ``flaring'' from saturation ghosts
     bogus_2:
       coordinates: [209.584254, 40.4601446]
-      title: Bogus "flaring" from a different artifact
+      title: Bogus ``flaring'' from a different artifact
     delta_scuti:
       coordinates: [279.9154053, 60.7140833]
       period: 0.064050575

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -190,6 +190,12 @@ docs:
       coordinates: [116.79866129999999, 51.4231961]
       period: 1.836431252123213
       title: Beta Lyrae
+    bogus_1:
+      coordinates: [328.1595911, 69.6487077]
+      title: Bogus "flaring" from saturation ghosts
+    bogus_2:
+      coordinates: [209.584254, 40.4601446]
+      title: Bogus "flaring" from a different artifact
     delta_scuti:
       coordinates: [279.9154053, 60.7140833]
       period: 0.064050575

--- a/doc/field_guide.md
+++ b/doc/field_guide.md
@@ -1,6 +1,6 @@
 # Field guide
 
-This guide provides detailed information about the different types of variable sources.
+This guide provides detailed information about the different types of variable sources along with examples of bogus variability.
 
 Proceed <a href="_static/taxonomy.html">here</a> to interactively inspect the taxonomy
 tree we are employing in SCoPe. Please refer to [arXiv:2102.11304](https://arxiv.org/pdf/2102.11304.pdf)
@@ -34,4 +34,7 @@ for more details on the taxonomy.
 ```
 
 ```{include} ./field_guide__lpv.md
+```
+
+```{include} ./field_guide__bogus.md
 ```

--- a/doc/field_guide__bogus.md
+++ b/doc/field_guide__bogus.md
@@ -1,0 +1,16 @@
+## Bogus variability (bogus)
+
+Not all light curve variability pertains to a source's intrinsic astrophysical nature. Some is caused by nearby extended objects, bright stars, blends and image artifacts, and being aware of how such bogus light curves appear can help avoid confusion.
+
+### ZTF light curves
+![ZTF bogus](data/bogus_1.png)
+![ZTF bogus](data/bogus_2.png)
+
+#### Description
+The first light curve above is caused by a saturation ghost artifact, and the second light curve suffers from another kind of artifact. These artifacts were analyzed and affected data masked after ZTF began, but data in earlier releases (such as the above from DR5) were not retroactively masked. This produces the apparent cutoff in variability after a certain point in time.
+
+#### Light curve characteristics
+The light curves appear to be "flaring" with departures from the median by multiple magnitudes until they suddenly go quiet in later data. The cutoff corresponds to the time when a new method of processing the data was used to mask affected points.
+
+### References and further reading:
+- [ZTF Explanatory Supplement (esp. Appendix B)](https://irsa.ipac.caltech.edu/data/ZTF/docs/ztf_explanatory_supplement.pdf)

--- a/doc/field_guide__bogus.md
+++ b/doc/field_guide__bogus.md
@@ -7,10 +7,10 @@ Not all light curve variability pertains to a source's intrinsic astrophysical n
 ![ZTF bogus](data/bogus_2.png)
 
 #### Description
-The first light curve above is caused by a saturation ghost artifact, and the second light curve suffers from another kind of artifact. These artifacts were analyzed and affected data masked after ZTF began, but data in earlier releases (such as the above from DR5) were not retroactively masked. This produces the apparent cutoff in variability after a certain point in time.
+The first light curve above demonstrates a saturation ghost artifact, and the second light curve suffers from another kind of artifact. These artifacts were identified and affected data masked after ZTF began, but data in earlier releases (such as the above from DR5) were not retroactively masked. This produces the apparent cutoff in variability after a certain point in time.
 
 #### Light curve characteristics
-The light curves appear to be "flaring" with departures from the median by multiple magnitudes until they suddenly go quiet in later data. The cutoff corresponds to the time when a new method of processing the data was used to mask affected points.
+The light curves appear to be "flaring" with departures from the median by multiple magnitudes which suddenly stop in later data. This cutoff corresponds to the time when a new method of processing the data was used to mask affected points.
 
 ### References and further reading:
 - [ZTF Explanatory Supplement (esp. Appendix B)](https://irsa.ipac.caltech.edu/data/ZTF/docs/ztf_explanatory_supplement.pdf)

--- a/doc/field_guide__cepheid.md
+++ b/doc/field_guide__cepheid.md
@@ -1,4 +1,4 @@
-## Classical Cepheids (cep)
+## Classical Cepheids (ceph)
 Classical Cepheids are young, bright (100-10,000 solar luminosities) supergiant stars that pulsate with periods of 1 to 100 days (typically several days). They are located in the main instability strip in the H-R diagram. Cepheids follow a famous pulsation period-luminosity relation, allowing the absolute magnitude of a Cepheid, and thus its distance, to be inferred from the pulsation period. Thus, Cepheids are used to measure distances to nearby galaxies.
 
 ### Classification and numbers

--- a/doc/field_guide__flaring.md
+++ b/doc/field_guide__flaring.md
@@ -1,4 +1,4 @@
-## Flaring variables (flaring)
+## Flaring variables (fla)
 
 The phenomelogical classification of ``flaring`` is any kind of outbursting source, where a variable star (or binary system) dramatically increases in brightness for minutes to hours before returning to quiescence. Most flare stars are red dwarfs, while RS Canum Venaticorum variables (RS CVn) are also known to flare due to a companion star in the binary system. Other possible sources of flaring include dwarf novae, which arise from accretion disk activity in a cataclysmic variable star.
 

--- a/doc/field_guide__periodic.md
+++ b/doc/field_guide__periodic.md
@@ -1,4 +1,4 @@
-## Periodic Variables (periodic)
+## Periodic Variables (pnp)
 Periodic Variables are objects that exhibit repeating sequences of values over a fixed length of time, known as the period.
 Many astrophysical objects exhibit periodic behavior, including eclipsing binaries, pulsators, etc.
 

--- a/doc/field_guide__variable.md
+++ b/doc/field_guide__variable.md
@@ -1,4 +1,4 @@
-## Variable stars (variable)
+## Variable stars (vnv)
 Variable stars are objects whose brightness is varying at a statistically significant level.
 ZTF has statistical measurements depend on magnitude: down to ~10 millimagnitudes for bright stars and >0.1 mag for objects near the detection limit.
 Many astrophysical objects exhibit variable behavior, including periodic variables such as eclipsing binaries, pulsators, etc, and non-periodic variables such as AGN and YSOs.


### PR DESCRIPTION
This PR adds a field guide section with examples of bogus variability (specifically apparent flaring sources). It also updates the label abbreviations for other field guide sections (e.g. for `periodic`, the abbreviation is `pnp`). 