### PR TITLE
Generate features for fields specified in config

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1340,6 +1340,10 @@ feature_generation:
       - ECE
       - EAOV
       - ELS
+  fields_to_run:
+    # If this list is populated, generate_features_job_submission.py will only run on the specified fields.
+    - 296
+    - 297
   cesium_features:
     # Some features on this list are already computed by lcstats - these are commented below
     #

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1341,9 +1341,9 @@ feature_generation:
       - EAOV
       - ELS
   fields_to_run:
-    # If this list is populated, generate_features_job_submission.py will only run on the specified fields.
-    - 296
-    - 297
+    # If this list is populated (example below), generate_features_job_submission.py will only run on the specified fields.
+    #- 296
+    #- 297
   cesium_features:
     # Some features on this list are already computed by lcstats - these are commented below
     #

--- a/tools/generate_features_job_submission.py
+++ b/tools/generate_features_job_submission.py
@@ -120,7 +120,7 @@ def run_job(df, quadrant_index, resultsDir, filename, runParallel=False):
 
     if not os.path.isfile(filepath):
         if runParallel:
-            sbatchstr = f"sbatch --export=QID={row['job_number'].values[0]} {qsubfile}"
+            sbatchstr = f"sbatch --export=QID={row['job_number']} {qsubfile}"
             print(sbatchstr)
             os.system(sbatchstr)
         else:


### PR DESCRIPTION
This PR enables feature generation on user-specified lists of fields, supplementing the default behavior that randomly selects quadrants from all available fields.

A fix is included that removes the code's ability to call feature generation on the same quadrant multiple times. This is unlikely early in the process but becomes more probable as the number of remaining quadrants decreases. The code also now terminates its loop of feature generation calls before performing any duplication at the very end of the process. When the number of available instances equals the number remaining jobs to be done, the code will stop looping after it submits these last jobs. 

There remains the possibility that a dwindling HPC allocation will hinder this code, since slurm will refuse jobs that request more time than remains on the allocation (even if the jobs run in less time than requested). This code does not currently recognize these refusals and will assume that each job that it attempted to submit did get queued.