### PR TITLE
Set ZTF DR16 as default sources catalog

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -9,8 +9,8 @@ kowalski:
   timeout: 300
   collections:
     gaia: Gaia_EDR3
-    # Current sources are from DR15 (on melman)
-    sources: ZTF_sources_20230109
+    # Current sources are from DR16 (on melman)
+    sources: ZTF_sources_20230309
     # Current features generated from DR5 (on gloria)
     features: ZTF_source_features_DR5
     # Current classifications are from DR5 (on gloria)

--- a/tools/generate_features_slurm.py
+++ b/tools/generate_features_slurm.py
@@ -238,7 +238,7 @@ if __name__ == "__main__":
         "--filename",
         type=str,
         default='gen_features',
-        help="if set, run on all quads for specified field/ccds",
+        help="Filename prefix for generated features",
     )
     parser.add_argument(
         "--doCesium",


### PR DESCRIPTION
This PR sets the newly available `ZTF_sources_20230309` collection on `melman` as the default sources catalog in the config file. A typo in an argparse description is also fixed.