### PR TITLE
Speed up scope.py test by scaling min period

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -1529,6 +1529,8 @@ class Scope:
                 stop_early=True,
                 Ncore=1,
                 min_n_lc_points=50,
+                doRemoveTerrestrial=True,
+                doScaleMinPeriod=True,
             )
 
             path_gen_features = (

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -469,7 +469,7 @@ def generate_features(
         # Define frequency grid using largest LC time baseline
         if doScaleMinPeriod:
             fmin, fmax = 2 / baseline, 1 / (
-                2 * args.min_cadence_minutes / 1440
+                2 * min_cadence_minutes / 1440
             )  # Nyquist frequency given minimum cadence converted to days
         else:
             fmin, fmax = 2 / baseline, 480


### PR DESCRIPTION
This PR uses the changes made in #346 to speed up `scope.py test`. There are now fewer frequencies for the L-S periodogram algorithm to analyze. In addition, the removal of terrestrial frequencies is now tested.