### PR TITLE
Add hyperparameter grid search to XGBoost training

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1574,6 +1574,24 @@ feature_generation:
 training:
   # Below, enter path to training set
   dataset: tools/fritzDownload/merged_classifications_features.parquet
+  xgboost:
+    # See scope.py train for descriptions of these parameters
+    gridsearch_params_start_stop_step:
+      max_depth: [3, 8, 2]
+      min_child_weight: [1, 6, 2]
+      # subsample, colsample values get divided by 10
+      # (default values produce .6, .8, 1.0)
+      subsample: [6, 11, 2]
+      colsample_bytree: [6, 11, 2]
+    other_training_params:
+      eta: [0.3, 0.2, 0.1, 0.05]
+      seed: 42
+      nfold: 5
+      metrics: ['auc']
+      objective: 'binary:logistic'
+      eval_metric: 'auc'
+      early_stopping_rounds: 10
+      num_boost_round: 999
   classes:
     # phenomenological classes
     vnv:

--- a/scope.py
+++ b/scope.py
@@ -535,7 +535,7 @@ class Scope:
         from scope.xgb import XGB
         from scope.utils import Dataset
 
-        train_config = self.config["training"]["classes"][tag]
+        label_params = self.config["training"]["classes"][tag]
         train_config_xgb = self.config["training"]['xgboost']
 
         if algorithm in ['DNN', 'NN', 'dnn', 'nn']:
@@ -545,7 +545,7 @@ class Scope:
         else:
             raise ValueError('Current supported algorithms are DNN and XGB.')
 
-        all_features = self.config["features"][train_config["features"]]
+        all_features = self.config["features"][label_params["features"]]
         features = [
             key for key in all_features if forgiving_true(all_features[key]["include"])
         ]
@@ -559,28 +559,28 @@ class Scope:
             **kwargs,
         )
 
-        label = train_config["label"]
+        label = label_params["label"]
 
         # values from kwargs override those defined in config. if latter is absent, use reasonable default
-        threshold = kwargs.get("threshold", train_config.get("threshold", 0.5))
-        balance = kwargs.get("balance", train_config.get("balance", None))
+        threshold = kwargs.get("threshold", label_params.get("threshold", 0.5))
+        balance = kwargs.get("balance", label_params.get("balance", None))
         weight_per_class = kwargs.get(
-            "weight_per_class", train_config.get("weight_per_class", False)
+            "weight_per_class", label_params.get("weight_per_class", False)
         )
         scale_features = kwargs.get("scale_features", "min_max")
 
-        test_size = kwargs.get("test_size", train_config.get("test_size", 0.1))
-        val_size = kwargs.get("val_size", train_config.get("val_size", 0.1))
-        random_state = kwargs.get("random_state", train_config.get("random_state", 42))
+        test_size = kwargs.get("test_size", label_params.get("test_size", 0.1))
+        val_size = kwargs.get("val_size", label_params.get("val_size", 0.1))
+        random_state = kwargs.get("random_state", label_params.get("random_state", 42))
         feature_stats = kwargs.get("feature_stats", None)
         if feature_stats == 'config':
             feature_stats = self.config.get("feature_stats", None)
 
-        batch_size = kwargs.get("batch_size", train_config.get("batch_size", 64))
+        batch_size = kwargs.get("batch_size", label_params.get("batch_size", 64))
         shuffle_buffer_size = kwargs.get(
-            "shuffle_buffer_size", train_config.get("shuffle_buffer_size", 512)
+            "shuffle_buffer_size", label_params.get("shuffle_buffer_size", 512)
         )
-        epochs = kwargs.get("epochs", train_config.get("epochs", 100))
+        epochs = kwargs.get("epochs", label_params.get("epochs", 100))
         float_convert_types = kwargs.get("float_convert_types", (64, 32))
 
         datasets, indexes, steps_per_epoch, class_weight = ds.make(

--- a/scope.py
+++ b/scope.py
@@ -536,6 +536,7 @@ class Scope:
         from scope.utils import Dataset
 
         train_config = self.config["training"]["classes"][tag]
+        train_config_xgb = self.config["training"]['xgboost']
 
         if algorithm in ['DNN', 'NN', 'dnn', 'nn']:
             algorithm = 'dnn'
@@ -613,26 +614,76 @@ class Scope:
         save = kwargs.get("save", False)
         plot = kwargs.get("plot", False)
         weights_only = kwargs.get("weights_only", False)
+        skip_cv = kwargs.get("skip_cv", False)
 
         # xgb-specific arguments (descriptions adapted from https://xgboost.readthedocs.io/en/stable/parameter.html and https://xgboost.readthedocs.io/en/stable/python/python_api.html)
         # max_depth: maximum depth of a tree
-        max_depth = kwargs.get("xgb_max_depth", 6)
+        max_depth_config = train_config_xgb['gridsearch_params_start_stop_step'].get(
+            'max_depth', [3, 8, 2]
+        )
+        max_depth_start = max_depth_config[0]
+        max_depth_stop = max_depth_config[1]
+        max_depth_step = max_depth_config[2]
+
         # min_child_weight: minimum sum of instance weight (hessian) needed in a child
-        min_child_weight = kwargs.get("xgb_min_child_weight", 1)
-        # eta: Step size shrinkage used in update to prevent overfitting
-        eta = kwargs.get("xgb_eta", 0.1)
+        min_child_weight_config = train_config_xgb[
+            'gridsearch_params_start_stop_step'
+        ].get('min_child_weight', [1, 6, 2])
+        min_child_weight_start = min_child_weight_config[0]
+        min_child_weight_stop = min_child_weight_config[1]
+        min_child_weight_step = min_child_weight_config[2]
+
+        # eta = kwargs.get("xgb_eta", 0.1)
+        eta_list = train_config_xgb['other_training_params'].get(
+            'eta_list', [0.3, 0.2, 0.1, 0.05]
+        )
+
         # subsample: Subsample ratio of the training instances (setting to 0.5 means XGBoost would randomly sample half of the training data prior to growing trees)
-        subsample = kwargs.get("xgb_subsample", 0.7)
+        # subsample = kwargs.get("xgb_subsample", 0.7)
+        subsample_config = train_config_xgb['gridsearch_params_start_stop_step'].get(
+            'subsample', [6, 11, 2]
+        )
+        subsample_start = subsample_config[0]
+        subsample_stop = subsample_config[1]
+        subsample_step = subsample_config[2]
+
         # colsample_bytree: subsample ratio of columns when constructing each tree.
-        colsample_bytree = kwargs.get("xgb_colsample_bytree", 0.7)
+        # colsample_bytree = kwargs.get("xgb_colsample_bytree", 0.7)
+        colsample_bytree_config = train_config_xgb[
+            'gridsearch_params_start_stop_step'
+        ].get('subsample', [6, 11, 2])
+        colsample_bytree_start = colsample_bytree_config[0]
+        colsample_bytree_stop = colsample_bytree_config[1]
+        colsample_bytree_step = colsample_bytree_config[2]
+
+        # seed: random seed
+        seed = train_config_xgb['other_training_params'].get('seed', 42)
+
+        # nfold: number of folds during cross-validation
+        nfold = train_config_xgb['other_training_params'].get('nfold', 5)
+
+        # metrics: evaluation metrics to use during cross-validation
+        metrics = train_config_xgb['other_training_params'].get('metrics', ['auc'])
+
         # objective: name of learning objective
-        objective = kwargs.get("xgb_objective", "binary:logistic")
+        objective = train_config_xgb['other_training_params'].get(
+            "objective", "binary:logistic"
+        )
+
         # eval_metric: Evaluation metrics for validation data
-        eval_metric = kwargs.get("xgb_eval_metric", "auc")
+        eval_metric = train_config_xgb['other_training_params'].get(
+            "eval_metric", "auc"
+        )
+
         # early_stopping_rounds: Validation metric needs to improve at least once in every early_stopping_rounds round(s) to continue training
-        early_stopping_rounds = kwargs.get("xgb_early_stopping_rounds", 10)
+        early_stopping_rounds = train_config_xgb['other_training_params'].get(
+            "early_stopping_rounds", 10
+        )
+
         # num_boost_round: Number of boosting iterations
-        num_boost_round = kwargs.get("xgb_num_boost_round", 999)
+        num_boost_round = train_config_xgb['other_training_params'].get(
+            "num_boost_round", 999
+        )
 
         # parse boolean args
         dense_branch = forgiving_true(dense_branch)
@@ -732,11 +783,11 @@ class Scope:
             # Add code to train XGB algorithm
             classifier = XGB(name=tag)
             classifier.setup(
-                max_depth=max_depth,
-                min_child_weight=min_child_weight,
-                eta=eta,
-                subsample=subsample,
-                colsample_bytree=colsample_bytree,
+                max_depth=max_depth_start,
+                min_child_weight=min_child_weight_start,
+                eta=eta_list[0],
+                subsample=subsample_start / 10.0,
+                colsample_bytree=colsample_bytree_start / 10.0,
                 objective=objective,
                 eval_metric=eval_metric,
                 early_stopping_rounds=early_stopping_rounds,
@@ -747,6 +798,23 @@ class Scope:
                 y_train,
                 X_val,
                 y_val,
+                skip_cv=skip_cv,
+                seed=seed,
+                nfold=nfold,
+                metrics=metrics,
+                max_depth_start=max_depth_start,
+                max_depth_stop=max_depth_stop,
+                max_depth_step=max_depth_step,
+                min_child_weight_start=min_child_weight_start,
+                min_child_weight_stop=min_child_weight_stop,
+                min_child_weight_step=min_child_weight_step,
+                eta_list=eta_list,
+                subsample_start=subsample_start,
+                subsample_stop=subsample_stop,
+                subsample_step=subsample_step,
+                colsample_bytree_start=colsample_bytree_start,
+                colsample_bytree_stop=colsample_bytree_stop,
+                colsample_bytree_step=colsample_bytree_step,
             )
 
         if verbose:
@@ -1641,6 +1709,7 @@ class Scope:
                         save=True,
                         test=True,
                         algorithm=algorithm,
+                        skip_cv=True,
                     )
                     path_model = (
                         pathlib.Path(__file__).parent.absolute()

--- a/scope.py
+++ b/scope.py
@@ -1722,7 +1722,6 @@ class Scope:
 
             print('model_paths', model_paths)
 
-            # Only testing DNN inference for now; XGB to be added
             with status("Test inference"):
                 print()
                 print(model_paths[1])
@@ -1732,7 +1731,6 @@ class Scope:
                     field=0,
                     whole_field=True,
                     trainingSet=df_mock,
-                    algorithm='dnn',
                 )
                 print(model_paths[0])
                 _, preds_filename_xgb = inference.run(

--- a/scope/xgb.py
+++ b/scope/xgb.py
@@ -1,8 +1,8 @@
 import pathlib
 from .models import AbstractClassifier
 import xgboost as xgb
-from sklearn.metrics import confusion_matrix
 from sklearn.metrics import (
+    confusion_matrix,
     roc_curve,
     auc,
     precision_recall_curve,
@@ -50,14 +50,198 @@ class XGB(AbstractClassifier):
         self.model = xgb.Booster(params=params)
 
     def train(self, X_train, y_train, X_val, y_val, **kwargs):
+        seed = kwargs.get('seed', 42)
+        nfold = kwargs.get('nfold', 5)
+        metrics = kwargs.get('metrics', ['auc'])
+
         dtrain = xgb.DMatrix(X_train, label=y_train)
         dval = xgb.DMatrix(X_val, label=y_val)
 
         # Evaluate on train and val sets
         evals = [(dtrain, 'dtrain'), (dval, 'dval')]
-
         self.meta['evals'] = evals
 
+        # Grid search for max_depth and min_child_weight params
+        gridsearch_params = [
+            (max_depth, min_child_weight)
+            for max_depth in range(3, 8, 2)
+            for min_child_weight in range(1, 6, 2)
+        ]
+        # Define initial best params and max AUC
+        best_params = None
+        max_auc = 0.0
+
+        for max_depth, min_child_weight in gridsearch_params:
+            print(
+                "CV with max_depth={}, min_child_weight={}".format(
+                    max_depth, min_child_weight
+                )
+            )
+            # Update our parameters
+            self.meta['params']['max_depth'] = max_depth
+            self.meta['params']['min_child_weight'] = min_child_weight
+            # Run CV
+            cv_results = xgb.cv(
+                self.meta['params'],
+                dtrain,
+                num_boost_round=self.meta['num_boost_round'],
+                seed=seed,
+                nfold=nfold,
+                metrics=metrics,
+                early_stopping_rounds=self.meta['early_stopping_rounds'],
+            )
+            # Update best AUC
+            mean_auc = cv_results['test-auc-mean'].max()
+            boost_rounds = cv_results['test-auc-mean'].argmax()
+            print("\tAUC {} for {} rounds".format(mean_auc, boost_rounds))
+            if mean_auc > max_auc:
+                max_auc = mean_auc
+                best_params = (max_depth, min_child_weight)
+        print(
+            "Best params: {}, {}, AUC: {}".format(
+                best_params[0], best_params[1], max_auc
+            )
+        )
+        self.meta['params']['max_depth'] = best_params[0]
+        self.meta['params']['min_child_weight'] = best_params[1]
+
+        # Grid search for subsample and colsample params
+        gridsearch_params = [
+            (subsample, colsample)
+            for subsample in [i / 10.0 for i in range(6, 11, 2)]
+            for colsample in [i / 10.0 for i in range(6, 11, 2)]
+        ]
+        best_params = None
+        max_auc = 0.0
+
+        # We start by the largest values and go down to the smallest
+        for subsample, colsample in reversed(gridsearch_params):
+            print("CV with subsample={}, colsample={}".format(subsample, colsample))
+            # Update our parameters
+            self.meta['params']['subsample'] = subsample
+            self.meta['params']['colsample_bytree'] = colsample
+            # Run CV
+            cv_results = xgb.cv(
+                self.meta['params'],
+                dtrain,
+                num_boost_round=self.meta['num_boost_round'],
+                seed=seed,
+                nfold=nfold,
+                metrics=metrics,
+                early_stopping_rounds=self.meta['early_stopping_rounds'],
+            )
+            # Update best AUC
+            mean_auc = cv_results['test-auc-mean'].max()
+            boost_rounds = cv_results['test-auc-mean'].argmax()
+            print("\tAUC {} for {} rounds".format(mean_auc, boost_rounds))
+            if mean_auc > max_auc:
+                max_auc = mean_auc
+                best_params = (subsample, colsample)
+        print(
+            "Best params: {}, {}, AUC: {}".format(
+                best_params[0], best_params[1], max_auc
+            )
+        )
+        self.meta['params']['subsample'] = best_params[0]
+        self.meta['params']['colsample_bytree'] = best_params[1]
+
+        best_params = None
+        max_auc = 0.0
+        for eta in [0.3, 0.2, 0.1, 0.05]:
+            print("CV with eta={}".format(eta))
+
+            # We update our parameters
+            self.meta['params']['eta'] = eta
+
+            # Run and time CV
+            cv_results = xgb.cv(
+                self.meta['params'],
+                dtrain,
+                num_boost_round=self.meta['num_boost_round'],
+                seed=seed,
+                nfold=nfold,
+                metrics=metrics,
+                early_stopping_rounds=self.meta['early_stopping_rounds'],
+            )
+
+            # Update best AUC
+            mean_auc = cv_results['test-auc-mean'].max()
+            boost_rounds = cv_results['test-auc-mean'].argmax()
+            print("\tAUC {} for {} rounds".format(mean_auc, boost_rounds))
+            if mean_auc > max_auc:
+                max_auc = mean_auc
+                best_params = eta
+        print("Best params: {}, AUC: {}".format(best_params, max_auc))
+        self.meta['params']['eta'] = best_params
+
+        # max_depth 3, 5, 7
+        # min_child_weight 1, 3, 5
+
+        # Best 7, 1
+
+        max_depth1 = self.meta['params']['max_depth'] - 1
+        max_depth2 = self.meta['params']['max_depth'] + 2
+        if max_depth1 < 1:
+            max_depth1 = 1
+        if max_depth2 > 9:
+            max_depth2 = 9
+
+        min_child_wt1 = self.meta['params']['min_child_weight'] - 1
+        min_child_wt2 = self.meta['params']['min_child_weight'] + 2
+        if min_child_wt1 < 1:
+            min_child_wt1 = 1
+        if min_child_wt2 > 9:
+            min_child_wt2 = 9
+
+        print(max_depth1, max_depth2, min_child_wt1, min_child_wt2)
+        # 6 9 1 3
+
+        # One more CV round for max_depth, min_child_weight params
+        gridsearch_params = [
+            (max_depth, min_child_weight)
+            for max_depth in range(max_depth1, max_depth2, 1)
+            for min_child_weight in range(min_child_wt1, min_child_wt2, 1)
+        ]
+
+        # Define initial best params and max AUC
+        best_params = None
+        max_auc = 0.0
+
+        for max_depth, min_child_weight in gridsearch_params:
+            print(
+                "CV with max_depth={}, min_child_weight={}".format(
+                    max_depth, min_child_weight
+                )
+            )
+            # Update our parameters
+            self.meta['params']['max_depth'] = max_depth
+            self.meta['params']['min_child_weight'] = min_child_weight
+            # Run CV
+            cv_results = xgb.cv(
+                self.meta['params'],
+                dtrain,
+                num_boost_round=self.meta['num_boost_round'],
+                seed=seed,
+                nfold=nfold,
+                metrics=metrics,
+                early_stopping_rounds=self.meta['early_stopping_rounds'],
+            )
+            # Update best AUC
+            mean_auc = cv_results['test-auc-mean'].max()
+            boost_rounds = cv_results['test-auc-mean'].argmax()
+            print("\tAUC {} for {} rounds".format(mean_auc, boost_rounds))
+            if mean_auc > max_auc:
+                max_auc = mean_auc
+                best_params = (max_depth, min_child_weight)
+        print(
+            "Best params: {}, {}, AUC: {}".format(
+                best_params[0], best_params[1], max_auc
+            )
+        )
+        self.meta['params']['max_depth'] = best_params[0]
+        self.meta['params']['min_child_weight'] = best_params[1]
+
+        # Train using optimized hyperparameters
         self.model = xgb.train(
             self.meta['params'],
             dtrain,
@@ -65,6 +249,15 @@ class XGB(AbstractClassifier):
             evals=self.meta['evals'],
             early_stopping_rounds=self.meta['early_stopping_rounds'],
             **kwargs,
+        )
+
+        # One more iteration of training (stop at best iteration)
+        self.meta['num_boost_round'] = self.model.best_iteration + 1
+        self.model = xgb.train(
+            self.meta['params'],
+            dtrain,
+            num_boost_round=self.meta['num_boost_round'],
+            evals=self.meta['evals'],
         )
 
     def predict(self, X, **kwargs):

--- a/scope/xgb.py
+++ b/scope/xgb.py
@@ -80,6 +80,7 @@ class XGB(AbstractClassifier):
 
         skip_cv = kwargs.get('skip_cv', True)
         if not skip_cv:
+            print('Running cross-validated hyperparameter grid search...')
             # Grid search for max_depth and min_child_weight params
             gridsearch_params = [
                 (max_depth, min_child_weight)
@@ -276,6 +277,7 @@ class XGB(AbstractClassifier):
             )
             self.meta['params']['max_depth'] = best_params[0]
             self.meta['params']['min_child_weight'] = best_params[1]
+            print('Grid search complete.')
 
         # Train using optimized hyperparameters
         self.model = xgb.train(

--- a/scope/xgb.py
+++ b/scope/xgb.py
@@ -279,19 +279,19 @@ class XGB(AbstractClassifier):
             self.meta['params']['min_child_weight'] = best_params[1]
 
             # One more CV round for subsample, colsample_bytree params
-            subsample1 = self.meta['params']['subsample'] - subsample_step
-            subsample2 = self.meta['params']['subsample'] + subsample_step
+            subsample1 = int(self.meta['params']['subsample'] * 10) - subsample_step
+            subsample2 = int(self.meta['params']['subsample'] * 10) + subsample_step
             if subsample1 < subsample_start:
                 subsample1 = subsample_start
             if subsample2 > subsample_stop - 1:
                 subsample2 = subsample_stop - 1
 
             colsample_bytree1 = (
-                self.meta['params']['colsample_bytree'] - colsample_bytree_step
-            )
+                self.meta['params']['colsample_bytree'] * 10
+            ) - colsample_bytree_step
             colsample_bytree2 = (
-                self.meta['params']['colsample_bytree'] + colsample_bytree_step
-            )
+                self.meta['params']['colsample_bytree'] * 10
+            ) + colsample_bytree_step
             if colsample_bytree1 < colsample_bytree_start:
                 colsample_bytree1 = colsample_bytree_start
             if colsample_bytree2 > colsample_bytree_stop - 1:
@@ -303,8 +303,10 @@ class XGB(AbstractClassifier):
 
             gridsearch_params = [
                 (subsample, colsample_bytree)
-                for subsample in range(subsample1, subsample2, 1)
-                for colsample_bytree in range(colsample_bytree1, colsample_bytree2, 1)
+                for subsample in [i / 10.0 for i in range(subsample1, subsample2, 1)]
+                for colsample_bytree in [
+                    i / 10.0 for i in range(colsample_bytree1, colsample_bytree2, 1)
+                ]
             ]
 
             # Define initial best params and max AUC

--- a/scope/xgb.py
+++ b/scope/xgb.py
@@ -48,8 +48,6 @@ class XGB(AbstractClassifier):
         self.meta['num_boost_round'] = num_boost_round
         self.meta['params'] = params
 
-        self.model = xgb.Booster(params=params)
-
     def train(self, X_train, y_train, X_val, y_val, **kwargs):
         seed = kwargs.get('seed', 42)
         nfold = kwargs.get('nfold', 5)
@@ -316,19 +314,23 @@ class XGB(AbstractClassifier):
         return self.model.eval(dtest, 'dtest', **kwargs)
 
     def load(self, path_model, **kwargs):
+        self.model = xgb.Booster()
+
         plpath = pathlib.Path(path_model)
         name = pathlib.Path(plpath.name)
         parent = plpath.parent
         filename = name.with_suffix('')
         cfg_filename = str(filename) + '.params'
-        print(str(parent / cfg_filename))
+
         try:
+            # Load .json model file
             self.model.load_model(path_model, **kwargs)
+            # Load .params file
             with open(str(parent / cfg_filename), 'r') as f:
                 cfg = json.load(f)
+            # Convert config dict to str
             cfg = json.dumps(cfg)
-            print(cfg)
-            print(type(cfg))
+            # Load optimal hyperparameters
             self.model.load_config(cfg)
         except Exception as e:
             print('Failure during model loading:')

--- a/scope/xgb.py
+++ b/scope/xgb.py
@@ -287,10 +287,10 @@ class XGB(AbstractClassifier):
                 subsample2 = subsample_stop - 1
 
             colsample_bytree1 = (
-                self.meta['params']['colsample_bytree'] * 10
+                int(self.meta['params']['colsample_bytree'] * 10)
             ) - colsample_bytree_step
             colsample_bytree2 = (
-                self.meta['params']['colsample_bytree'] * 10
+                int(self.meta['params']['colsample_bytree'] * 10)
             ) + colsample_bytree_step
             if colsample_bytree1 < colsample_bytree_start:
                 colsample_bytree1 = colsample_bytree_start

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -287,7 +287,6 @@ def run(
         model = tf.keras.models.load_model(path_model)
     elif algorithm == 'xgb':
         model = XGB(name=model_class)
-        model.setup()
         model.load(path_model)
     te = time.time()
     if tm:


### PR DESCRIPTION
This PR adds a hyperparameter cross-validation grid search to XGBoost, with the range of each grid customizable in the config file. The optimal parameters are saved/loaded from a new .params file that accompanies the saved model. The `load_config()` method has been tested, and it successfully loads the parameters and associates them with an instantiated model. 

As in the original jupyter notebook running this code, the grid search begins with the `max_depth` and `min_child_weights` parameters and continues with `subsample` and `colsample_bytree`, then `eta`, then one more round of `max_depth` and `min_child_weights`.