### PR TITLE
Enable feature generation for user-specified sources

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1333,10 +1333,13 @@ feature_stats:
 
 # Below, specify algorithms, external catalogs and features to include in generated feature lists:
 feature_generation:
-  # If doSpecificIDs is set in generate_features.py, the script will generate features for the below dataset instead of a field/ccd/quad.
+  # If --doSpecificIDs is set in generate_features.py, the script will generate features for the below dataset instead of a field/ccd/quad.
   # Dataset must contain columns named "ztf_id" and "coordinates" with data corresponding to these fields on Kowalski
   # Default dataset is the training set downloadable from Fritz
   dataset: tools/fritzDownload/merged_classifications_features.parquet
+  # Once generate_features.py is run with --doSpecificIDs, a file will be saved with the default name below.
+  # Set --doNotRemoveCloseSources to load the file below and skip the idenfication of close sources:
+  dataset_skipGaia: tools/fritzDownload/merged_classifications_features_dropCloseSources.parquet
   period_algorithms:
     CPU:
       - LS

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1334,12 +1334,12 @@ feature_stats:
 # Below, specify algorithms, external catalogs and features to include in generated feature lists:
 feature_generation:
   # If --doSpecificIDs is set in generate_features.py, the script will generate features for the below dataset instead of a field/ccd/quad.
-  # Dataset must contain columns named "ztf_id" and "coordinates" with data corresponding to these fields on Kowalski
+  # Dataset must contain columns named "ztf_id" and "coordinates" with data in the format of these fields on Kowalski
   # Default dataset is the training set downloadable from Fritz
   dataset: tools/fritzDownload/merged_classifications_features.parquet
   # Once generate_features.py is run with --doSpecificIDs, a file will be saved with the default name below.
-  # Set --doNotRemoveCloseSources to load the file below and skip the idenfication of close sources:
-  dataset_skipGaia: tools/fritzDownload/merged_classifications_features_dropCloseSources.parquet
+  # Set --skipCloseSources to load the file below and skip the idenfication of close sources:
+  ids_skipGaia: tools/fritzDownload/specific_ids_dropCloseSources.json
   period_algorithms:
     CPU:
       - LS

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1333,6 +1333,10 @@ feature_stats:
 
 # Below, specify algorithms, external catalogs and features to include in generated feature lists:
 feature_generation:
+  # If doSpecificIDs is set in generate_features.py, the script will generate features for the below dataset instead of a field/ccd/quad.
+  # Dataset must contain columns named "ztf_id" and "coordinates" with data corresponding to these fields on Kowalski
+  # Default dataset is the training set downloadable from Fritz
+  dataset: tools/fritzDownload/merged_classifications_features.parquet
   period_algorithms:
     CPU:
       - LS

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -599,13 +599,13 @@ def generate_features(
 
         else:
             feature_gen_source_list = {
-                int(k): fg_sources[k] for k in list(fg_sources)[:limit]
+                int(k): fg_sources[k] for k in list(fg_sources)[:n_fg_sources]
             }
 
     print('Getting lightcurves...')
     # For small source lists, shrink LC query limit until batching occurs
     lc_limit = limit
-    if Ncore > 1:
+    if len(feature_gen_source_list) < limit:
         lc_limit = int(np.ceil(len(feature_gen_source_list) / Ncore))
 
     lcs = get_lightcurves_via_ids(

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -525,8 +525,13 @@ def generate_features(
                 xmatch_radius_arcsec=xmatch_radius_arcsec,
             )
     else:
-        # Read ztf_id column from csv, hdf5 or parquet file specified in config entry
-        fg_sources_config = config['feature_generation']['dataset']
+        if not doNotRemoveCloseSources:
+            # Read ztf_id column from csv, hdf5 or parquet file specified in config entry
+            fg_sources_config = config['feature_generation']['dataset']
+        else:
+            # Load pre-saved dataset if Gaia analysis already complete
+            fg_sources_config = config['feature_generation']['dataset_skipGaia']
+
         fg_sources_path = str(BASE_DIR / fg_sources_config)
 
         if fg_sources_path.endswith('.parquet'):


### PR DESCRIPTION
This PR adds (and in some cases, re-implements) functionality to `generate_features.py` to generate features for ZTF light curves with IDs from a config-specified file. A new `--doSpecificIDs` flag is added to the script to trigger the workflow.

The older query-by-ID approach (removed in #322) is employed to identify sources too close to bright stars in Gaia EDR3. As a solution to avoid wasting time on HPC resources, the script can now save the output from this query/analysis and then skip that step in subsequent runs (set `--skipCloseSources`). The faster approach is still used when generating features for a given field/cdd/quadrant.

This code will be especially useful for generating up-to-date features for our training set and testing period-finding algorithms.