### PR TITLE
Fix failing test suite by removing melman references

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -9,8 +9,8 @@ kowalski:
   timeout: 300
   collections:
     gaia: Gaia_EDR3
-    # Current sources are from DR16 (on melman)
-    sources: ZTF_sources_20230309
+    # Current sources are from DR5 (while melman is unavailable)
+    sources: ZTF_sources_20210401
     # Current features generated from DR5 (on gloria)
     features: ZTF_source_features_DR5
     # Current classifications are from DR5 (on gloria)

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -509,7 +509,7 @@ def generate_features(
         _, lst = get_ids_loop(
             get_field_ids,
             catalog=source_catalog,
-            kowalski_instance=kowalski_instances['melman'],
+            kowalski_instance=kowalski_instances['gloria'],
             limit=limit,
             field=field,
             ccd_range=ccd,
@@ -614,7 +614,7 @@ def generate_features(
     feature_gen_ids = [x for x in feature_gen_source_dict.keys()]
 
     lcs = get_lightcurves_via_ids(
-        kowalski_instance=kowalski_instances['melman'],
+        kowalski_instance=kowalski_instances['gloria'],
         ids=feature_gen_ids,
         catalog=source_catalog,
         limit_per_query=lc_limit,


### PR DESCRIPTION
This PR fixes the failing scope test suite by switching hardcoded `melman` references to `gloria`. This will need to be undone once `melman` is available in order for feature generation to run on the correct catalog. Once the latest version of `penquins` is released, the code will no longer need these references to specific instances (see #330).