### PR TITLE
Add additional hyphen to arguments in download/upload/annot scripts

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -258,7 +258,7 @@ process:
 output: data with new columns appended.
 
 ```sh
-./scope_download_classification.py -file sample.csv -group_ids 360 361 -start 10 -merge_features True -features_catalog ZTF_source_features_DR5 -features_limit 5000 -taxonomy_map golden_dataset_mapper.json -output_dir fritzDownload -output_filename merged_classifications_features -output_format parquet -get_ztf_filters -impute_missing_features
+./scope_download_classification.py --file sample.csv --group_ids 360 361 --start 10 --merge_features True --features_catalog ZTF_source_features_DR5 --features_limit 5000 --taxonomy_map golden_dataset_mapper.json --output_dir fritzDownload --output_filename merged_classifications_features --output_format parquet -get_ztf_filters --impute_missing_features
 ```
 
 ## Scope Upload Classification
@@ -294,7 +294,7 @@ process:
 6. (post comment to each uploaded source)
 
 ```sh
-./scope_upload_classification.py -file sample.csv -group_ids 500 250 750 -classification variable flaring -taxonomy_map map.json -comment confident -start 35 -stop 50 -skip_phot -p_threshold 0.9 -write_obj_id -result_format csv -use_existing_obj_id -post_survey_id -replace_classifications
+./scope_upload_classification.py --file sample.csv --group_ids 500 250 750 --classification variable flaring --taxonomy_map map.json --comment confident --start 35 --stop 50 --skip_phot --p_threshold 0.9 --write_obj_id --result_format csv --use_existing_obj_id --post_survey_id --replace_classifications
 ```
 
 ## Scope Manage Annotation
@@ -312,7 +312,7 @@ process:
 3. confirm changes with printed messages
 
 ```sh
-./scope_manage_annotation.py -action post -source sample.csv -group_ids 200 300 400 -origin revisedperiod -key period
+./scope_manage_annotation.py --action post --source sample.csv --group_ids 200 300 400 --origin revisedperiod --key period
 ```
 
 ## Scope Upload Disagreements

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -636,13 +636,13 @@ def download_classification(
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-file", type=str, default='parse', help="dataset")
-    parser.add_argument("-group_ids", type=int, nargs='+', help="list of group ids")
+    parser.add_argument("--file", type=str, default='parse', help="dataset")
+    parser.add_argument("--group_ids", type=int, nargs='+', help="list of group ids")
     parser.add_argument(
         "-start", type=int, default=0, help="start page/index for continued download"
     )
     parser.add_argument(
-        "-merge_features",
+        "--merge_features",
         type=bool,
         nargs='?',
         const=True,
@@ -650,56 +650,56 @@ if __name__ == "__main__":
         help="merge downloaded results with features from Kowalski",
     )
     parser.add_argument(
-        "-features_catalog",
+        "--features_catalog",
         type=str,
         default=features_catalog,
         help="catalog of features on Kowalski",
     )
 
     parser.add_argument(
-        "-features_limit",
+        "--features_limit",
         type=int,
         default=1000,
         help="Maximum number of sources queried for features per loop",
     )
 
     parser.add_argument(
-        "-taxonomy_map",
+        "--taxonomy_map",
         type=str,
         default='golden_dataset_mapper.json',
         help="JSON file mapping between origin labels and Fritz taxonomy",
     )
 
     parser.add_argument(
-        "-output_dir",
+        "--output_dir",
         type=str,
         default='fritzDownload',
         help="Name of directory to save downloaded file",
     )
 
     parser.add_argument(
-        "-output_filename",
+        "--output_filename",
         type=str,
         default='merged_classifications_features',
         help="Name of output file containing merged classifications and features",
     )
 
     parser.add_argument(
-        "-output_format",
+        "--output_format",
         type=str,
         default='parquet',
         help="Format of output file: parquet, h5 or csv",
     )
 
     parser.add_argument(
-        "-get_ztf_filters",
+        "--get_ztf_filters",
         action='store_true',
         default=False,
         help="add ZTF filter ID to default features",
     )
 
     parser.add_argument(
-        "-impute_missing_features",
+        "--impute_missing_features",
         action='store_true',
         default=False,
         help="impute missing features using strategy specified by config",

--- a/tools/scope_manage_annotation.py
+++ b/tools/scope_manage_annotation.py
@@ -178,12 +178,12 @@ def manage_annotation(action, source, group_ids, origin, key, value):
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-action", help="post, update, or delete annotation")
-    parser.add_argument("-source", help="Fritz object id or csv file of sources")
-    parser.add_argument("-group_ids", type=int, nargs='+', help="list of group ids")
-    parser.add_argument("-origin", type=str, help="name of annotation origin")
-    parser.add_argument("-key", help="annotation key")
-    parser.add_argument("-value", type=str, help="annotation value")
+    parser.add_argument("--action", help="post, update, or delete annotation")
+    parser.add_argument("--source", help="Fritz object id or csv file of sources")
+    parser.add_argument("--group_ids", type=int, nargs='+', help="list of group ids")
+    parser.add_argument("--origin", type=str, help="name of annotation origin")
+    parser.add_argument("--key", help="annotation key")
+    parser.add_argument("--value", type=str, help="annotation value")
 
     args = parser.parse_args()
 

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -510,31 +510,31 @@ if __name__ == "__main__":
     gloria = Kowalski(**config['kowalski'], verbose=False)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-file", help="dataset with .csv, .h5 or .parquet extension")
-    parser.add_argument("-group_ids", type=int, nargs='+', help="list of group ids")
+    parser.add_argument("--file", help="dataset with .csv, .h5 or .parquet extension")
+    parser.add_argument("--group_ids", type=int, nargs='+', help="list of group ids")
 
     # parser.add_argument("-classification", type=str, help="name of object class")
     parser.add_argument(
-        "-classification", type=str, nargs='+', help="list of object classes"
+        "--classification", type=str, nargs='+', help="list of object classes"
     )
     parser.add_argument(
-        "-taxonomy_map",
+        "--taxonomy_map",
         type=str,
         help="JSON file mapping between origin labels and Fritz taxonomy",
     )
     parser.add_argument(
-        "-comment",
+        "--comment",
         type=str,
         help="Post specified string to comments for sources in file",
     )
     parser.add_argument("-start", type=int, help="Zero-based index to start uploading")
     parser.add_argument(
-        "-stop",
+        "--stop",
         type=int,
         help="Index to stop uploading (inclusive)",
     )
     parser.add_argument(
-        "-skip_phot",
+        "--skip_phot",
         type=bool,
         nargs='?',
         default=False,
@@ -543,83 +543,83 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-post_survey_id",
+        "--post_survey_id",
         action='store_true',
         help="If set, post survey_id from input dataset.",
     )
 
     parser.add_argument(
-        "-survey_id_origin",
+        "--survey_id_origin",
         type=str,
         default='SCoPe_xmatch',
         help="Annotation origin for survey ID",
     )
 
     parser.add_argument(
-        "-p_threshold",
+        "--p_threshold",
         type=float,
         default=0.0,
         help="Classification probability >= this number to upload",
     )
 
     parser.add_argument(
-        "-match_ids",
+        "--match_ids",
         action='store_true',
         default=False,
         help="If set, match input and existing sources using ZTF source IDs.",
     )
 
     parser.add_argument(
-        "-use_existing_obj_id",
+        "--use_existing_obj_id",
         action='store_true',
         default=False,
         help="If set, source obj_id from input dataset.",
     )
 
     parser.add_argument(
-        "-post_upvote",
+        "--post_upvote",
         action='store_true',
         default=False,
         help="If set, post upvote to new classifications.",
     )
 
     parser.add_argument(
-        "-check_labelled_box",
+        "--check_labelled_box",
         action='store_true',
         default=False,
         help="If set, check 'labelled' box for source.",
     )
 
     parser.add_argument(
-        "-write_obj_id",
+        "--write_obj_id",
         action='store_true',
         default=False,
         help="If set, write obj_ids corresponding to each uploaded source.",
     )
 
     parser.add_argument(
-        "-result_dir",
+        "--result_dir",
         type=str,
         default='fritzUpload',
         help="Directory to save upload results",
     )
 
     parser.add_argument(
-        "-result_filetag",
+        "--result_filetag",
         type=str,
         default='fritzUpload',
         help="Directory to save upload results",
     )
 
     parser.add_argument(
-        "-result_format",
+        "--result_format",
         type=str,
         default='parquet',
         help="Format of result file: parquet, h5 or csv",
     )
 
     parser.add_argument(
-        "-replace_classifications",
+        "--replace_classifications",
         action='store_true',
         default=False,
         help="If set, delete each object's existing classifications before posting new ones.",


### PR DESCRIPTION
Our Fritz download/upload/annotation scripts currently take command line arguments with one hyphen, e.g. `-file`. For the sake of consistency with our other scripts that take arguments (as well as Unix standards), this PR adds a second hyphen to all arguments longer than one character in these scripts. The documentation is updated accordingly.