### PR TITLE
Add XGB taxonomy mapper, modify DNN mapper

### DIFF
--- a/tools/XGB_AL_mapper.json
+++ b/tools/XGB_AL_mapper.json
@@ -1,225 +1,225 @@
 {
-    "vnv_dnn":
+    "vnv_xgb":
         {"fritz_label": "variable",
           "taxonomy_id": 1017
         },
 
-    "pnp_dnn":
+    "pnp_xgb":
         {"fritz_label": "periodic",
           "taxonomy_id": 1017
         },
 
-    "puls_dnn":
+    "puls_xgb":
         {"fritz_label": "Pulsating",
           "taxonomy_id": 1015
         },
 
-    "rrlyr_dnn":
+    "rrlyr_xgb":
         {"fritz_label": "RR Lyrae",
           "taxonomy_id": 1015
         },
 
-    "ceph_dnn":
+    "ceph_xgb":
         {"fritz_label": "Cepheid",
           "taxonomy_id": 1015
         },
 
-    "mp_dnn":
+    "mp_xgb":
         {"fritz_label": "multi periodic",
           "taxonomy_id": 1017
         },
 
-    "sin_dnn":
+    "sin_xgb":
         {"fritz_label": "sinusoidal",
           "taxonomy_id": 1017
         },
 
-    "nonvar_dnn":
+    "nonvar_xgb":
         {"fritz_label": "non-variable",
           "taxonomy_id": 1017
         },
 
-    "bogus_dnn":
+    "bogus_xgb":
         {"fritz_label": "bogus",
           "taxonomy_id": 1017
         },
 
-    "bright_dnn":
+    "bright_xgb":
         {"fritz_label": "bright star",
           "taxonomy_id": 1017
         },
 
-    "longt_dnn":
+    "longt_xgb":
         {"fritz_label": "long timescale",
           "taxonomy_id": 1017
         },
 
-    "i_dnn":
+    "i_xgb":
         {"fritz_label": "irregular",
           "taxonomy_id": 1017
         },
 
-    "e_dnn":
+    "e_xgb":
         {"fritz_label": "eclipsing",
           "taxonomy_id": 1017
         },
 
-    "ew_dnn":
+    "ew_xgb":
         {"fritz_label": "EW",
           "taxonomy_id": 1017
         },
 
-    "fla_dnn":
+    "fla_xgb":
         {"fritz_label": "flaring",
           "taxonomy_id": 1017
         },
 
-    "bis_dnn":
+    "bis_xgb":
         {"fritz_label": "Eclipsing",
           "taxonomy_id": 1015
         },
 
-    "emsms_dnn":
+    "emsms_xgb":
         {"fritz_label": "detached MS-MS",
           "taxonomy_id": 1015
         },
 
-    "wuma_dnn":
+    "wuma_xgb":
         {"fritz_label": "W Ursae Maj",
           "taxonomy_id": 1015
         },
 
-    "rrab_dnn":
+    "rrab_xgb":
         {"fritz_label": "RRab",
           "taxonomy_id": 1015
         },
 
-    "rrc_dnn":
+    "rrc_xgb":
         {"fritz_label": "RRc",
           "taxonomy_id": 1015
         },
 
-    "dscu_dnn":
+    "dscu_xgb":
         {"fritz_label": "Delta Scuti",
           "taxonomy_id": 1015
         },
 
-    "rrd_dnn":
+    "rrd_xgb":
         {"fritz_label": "RRd",
           "taxonomy_id": 1015
         },
 
-    "ceph2_dnn":
+    "ceph2_xgb":
         {"fritz_label": "Population II Cepheid",
           "taxonomy_id": 1015
         },
 
-    "rscvn_dnn":
+    "rscvn_xgb":
         {"fritz_label": "RS CVn",
         "taxonomy_id": 1015
         },
 
-    "eb_dnn":
+    "eb_xgb":
         {"fritz_label": "EB",
           "taxonomy_id": 1017
         },
 
-    "blyr_dnn":
+    "blyr_xgb":
         {"fritz_label": "Beta Lyrae",
           "taxonomy_id": 1015
         },
 
-    "saw_dnn":
+    "saw_xgb":
         {"fritz_label": "sawtooth",
           "taxonomy_id": 1017
         },
 
-    "ea_dnn":
+    "ea_xgb":
         {"fritz_label": "EA",
           "taxonomy_id": 1017
         },
 
-    "yso_dnn":
+    "yso_xgb":
         {"fritz_label": "YSO",
           "taxonomy_id": 1015
         },
 
-    "wp_dnn":
+    "wp_xgb":
         {"fritz_label": "wrong period",
           "taxonomy_id": 1017
         },
 
-    "agn_dnn":
+    "agn_xgb":
         {"fritz_label": "AGN",
           "taxonomy_id": 1015
         },
 
-    "lpv_dnn":
+    "lpv_xgb":
         {"fritz_label": "LPV",
           "taxonomy_id": 1015
         },
 
-    "mir_dnn":
+    "mir_xgb":
         {"fritz_label": "Mira",
           "taxonomy_id": 1015
         },
 
-    "hp_dnn":
+    "hp_xgb":
         {"fritz_label": "half period",
           "taxonomy_id": 1017
         },
 
-    "srv_dnn":
+    "srv_xgb":
         {"fritz_label": "Semiregular",
           "taxonomy_id": 1015
         },
 
-    "osarg_dnn":
+    "osarg_xgb":
         {"fritz_label": "OSARG",
           "taxonomy_id": 1015
         },
 
-    "el_dnn":
+    "el_xgb":
         {"fritz_label": "ellipsoidal",
           "taxonomy_id": 1017
         },
 
-    "blend_dnn":
+    "blend_xgb":
       {"fritz_label": "blend",
         "taxonomy_id": 1017
       },
 
-    "cv_dnn":
+    "cv_xgb":
       {"fritz_label": "Cataclysmic",
         "taxonomy_id": 1015
       },
 
-    "wvir_dnn":
+    "wvir_xgb":
       {"fritz_label": "W Vir",
         "taxonomy_id": 1015
       },
 
-    "rrblz_dnn":
+    "rrblz_xgb":
       {"fritz_label": "Blazhko",
         "taxonomy_id": 1015
       },
 
-    "blher_dnn":
+    "blher_xgb":
       {"fritz_label": "BL Her",
         "taxonomy_id": 1015
       },
 
-    "dip_dnn":
+    "dip_xgb":
       {"fritz_label": "dipping",
         "taxonomy_id": 1017
       },
 
-    "dp_dnn":
+    "dp_xgb":
       {"fritz_label": "double period",
         "taxonomy_id": 1017
       },
 
-    "ext_dnn":
+    "ext_xgb":
       {"fritz_label": "extended",
         "taxonomy_id": 1017
       }

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -527,7 +527,7 @@ if __name__ == "__main__":
         type=str,
         help="Post specified string to comments for sources in file",
     )
-    parser.add_argument("-start", type=int, help="Zero-based index to start uploading")
+    parser.add_argument("--start", type=int, help="Zero-based index to start uploading")
     parser.add_argument(
         "--stop",
         type=int,


### PR DESCRIPTION
This PR adds a Fritz taxonomy mapper file for labels from XGB and updates the DNN mapper to cover all current binary classifiers.