### PR TITLE
Add minobs filter to catalog completeness code

### DIFF
--- a/tools/generate_features_slurm.py
+++ b/tools/generate_features_slurm.py
@@ -54,6 +54,7 @@ def check_quads_for_sources(
     kowalski_instance_name: str = 'melman',
     catalog: str = source_catalog,
     count_sources: bool = False,
+    minobs: int = 0,
     save: bool = False,
     filename: str = 'catalog_completeness',
 ):
@@ -64,6 +65,7 @@ def check_quads_for_sources(
     :param kowalski_instance_name: name of kowalski instance to query (str)
     :param catalog: name of source catalog to query (str)
     :param count_sources: if set, count number of sources per quad and return (bool)
+    :param minobs: minimum number of observations needed to count a source (int)
     :param save: if set, save results dictionary in json format (bool)
     :param filename: filename of saved results (str)
 
@@ -110,17 +112,20 @@ def check_quads_for_sources(
                 else:
                     quads = []
                 for quadrant in range(1, 5):
+                    fltr = {
+                        'field': {'$eq': int(field)},
+                        'ccd': {'$eq': int(ccd)},
+                        'quad': {'$eq': int(quadrant)},
+                    }
+                    if minobs > 0:
+                        fltr.update({'nobs': {'$gte': int(minobs)}})
 
                     # Another minimal query for each ccd/quad combo
                     q = {
                         "query_type": 'count_documents',
                         "query": {
                             "catalog": catalog,
-                            "filter": {
-                                'field': {'$eq': int(field)},
-                                'ccd': {'$eq': int(ccd)},
-                                'quad': {'$eq': int(quadrant)},
-                            },
+                            "filter": fltr,
                         },
                     }
                     rsp = kowalski_instance.query(q)

--- a/tools/get_quad_ids.py
+++ b/tools/get_quad_ids.py
@@ -322,7 +322,7 @@ def get_field_ids(
         "quad": {"$eq": quad},
     }
     if minobs > 0:
-        filter["nobs"] = {"$gt": minobs}
+        filter["nobs"] = {"$gte": minobs}
 
     projection = {"_id": 1}
     if get_coords:


### PR DESCRIPTION
This PR adds a `minobs` argument to `check_quads_for_sources`. Setting this argument to the minimum number of light curve points enforced in scope (currently 50) will help provide more accurate feature generation runtime estimates. This is because the longest-running part of feature generation, the period finding, only runs on sources having ≥ `minobs` points. 

Also in this PR, a `$gt` is changed to `$gte$` in `get_quad_ids.py` to be consistent with the stated strategy of using light curves having N or more points.