### PR TITLE
Save inference results as parquet instead of hdf5

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -1386,7 +1386,7 @@ class Scope:
             print('Consolidating classification probabilities to one per source...')
             for field in fields:
                 print(field)
-                h = read_hdf(str(preds_path / field / f'{field}.h5'))
+                h = read_parquet(str(preds_path / field / f'{field}.parquet'))
                 consolidated_df, all_rows_df = self.consolidate_inference_results(
                     h, statistic=consolidation_statistic
                 )


### PR DESCRIPTION
This PR changes the default file format for inference results to parquet. This change, combined with the explicit conversion of integer fields to pandas `Int64` type, ensures that Kowalski ingests these fields as integers rather than floats.