### PR TITLE
Rename generated features index to '_id', reset index

### DIFF
--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -1031,6 +1031,10 @@ def generate_features(
         )
         feature_df = pd.DataFrame.from_dict(feature_dict, orient='index')
 
+        # Rename index column to '_id' and reset index
+        feature_df.index.set_names('_id', inplace=True)
+        feature_df.reset_index(inplace=True)
+
         # Convert various _id datatypes to Int64
         colnames = [x for x in feature_df.columns]
         for col in colnames:


### PR DESCRIPTION
Currently in `generate_features.py`, the ZTF ID for each source is stored as the index column. This PR renames that column to `_id` (to interface smoothly with kowalski/mongoDB) and then resets the index so the `_id` column can be accessed during ingestion.