### PR TITLE
Gcn workflow updates

### DIFF
--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -558,6 +558,14 @@ def generate_features(
                 raise KeyError(
                     'Columns "ztf_id" and "coordinates" must be included in source dataset.'
                 )
+
+            hasFritzNames = False
+            try:
+                fritz_names = fg_sources['fritz_name'].values.tolist()
+                hasFritzNames = True
+            except KeyError:
+                warnings.warn('No obj_id column found in dataset.')
+
         else:
             # Load pre-saved dataset if Gaia analysis already complete
             fg_sources_config = config['feature_generation']['ids_skipGaia']
@@ -575,8 +583,20 @@ def generate_features(
 
         if not skipCloseSources:
             # Create list with same structure as query results
-            lst = [
-                {
+            if hasFritzNames:
+                dct_for_lst = {
+                    ztf_ids[i]: {
+                        'radec_geojson': {
+                            'coordinates': coordinates[i]['radec_geojson'][
+                                'coordinates'
+                            ].tolist()
+                        },
+                        'fritz_name': fritz_names[i],
+                    }
+                    for i in range(n_fg_sources)
+                }
+            else:
+                dct_for_lst = {
                     ztf_ids[i]: {
                         'radec_geojson': {
                             'coordinates': coordinates[i]['radec_geojson'][
@@ -586,7 +606,9 @@ def generate_features(
                     }
                     for i in range(n_fg_sources)
                 }
-            ]
+
+            lst = [dct_for_lst]
+
             print(f'Loaded ZTF IDs for {len(lst[0])} sources.')
 
             # Each index of lst corresponds to a different ccd/quad combo

--- a/tools/scope_download_gcn_sources.py
+++ b/tools/scope_download_gcn_sources.py
@@ -144,11 +144,11 @@ def download_gcn_sources(
     coord_col = ids['coordinates']
     ids['radec_geojson'] = [row['radec_geojson'] for row in coord_col]
     ids.drop('coordinates', axis=1, inplace=True)
-    ids.rename({'obj_id': 'fritz_name'}, axis=1, inplace=True)
+    ids.rename({'_id': 'ztf_id', 'obj_id': 'fritz_name'}, axis=1, inplace=True)
 
     write_parquet(ids, str(BASE_DIR / f"{save_filename}.parquet"))
 
-    ids = ids.set_index('_id').to_dict(orient='index')
+    ids = ids.set_index('ztf_id').to_dict(orient='index')
     with open(str(BASE_DIR / f"{save_filename}.json"), 'w') as f:
         json.dump(ids, f)
 

--- a/tools/scope_download_gcn_sources.py
+++ b/tools/scope_download_gcn_sources.py
@@ -140,13 +140,13 @@ def download_gcn_sources(
     )
 
     ids = ids.drop_duplicates('_id').reset_index(drop=True)
+    ids.rename({'_id': 'ztf_id', 'obj_id': 'fritz_name'}, axis=1, inplace=True)
+
+    write_parquet(ids, str(BASE_DIR / f"{save_filename}.parquet"))
 
     coord_col = ids['coordinates']
     ids['radec_geojson'] = [row['radec_geojson'] for row in coord_col]
     ids.drop('coordinates', axis=1, inplace=True)
-    ids.rename({'_id': 'ztf_id', 'obj_id': 'fritz_name'}, axis=1, inplace=True)
-
-    write_parquet(ids, str(BASE_DIR / f"{save_filename}.parquet"))
 
     ids = ids.set_index('ztf_id').to_dict(orient='index')
     with open(str(BASE_DIR / f"{save_filename}.json"), 'w') as f:


### PR DESCRIPTION
This PR makes updates to feature generation and GCN source querying to make the workflow run more smoothly. Primarily:
- Bugfix: the page-by-page query was missing `localizationDateobs`, `startDate` and `endDate`.
- A parquet file is now generated by `scope_download_gcn_sources.py` to be used as the primary input to the feature generation script. `generate_features.py` handles this file smoothly and passes on the identifiers from Fritz if they are available.