### PR TITLE
Add new tokens to workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,9 @@ jobs:
       env:
         KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
         KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
+        KOWALSKI_INSTANCE_TOKEN: ${{ secrets.KOWALSKI_INSTANCE_TOKEN }}
+        GLORIA_INSTANCE_TOKEN: ${{ secrets.GLORIA_INSTANCE_TOKEN }}
+        MELMAN_INSTANCE_TOKEN: ${{ secrets.MELMAN_INSTANCE_TOKEN }}
       run: |
         ./scope.py doc
     - name: Install SSH Client 🔑

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,8 @@ jobs:
       env:
         KOWALSKI_TOKEN: ${{ secrets.KOWALSKI_TOKEN }}
         KOWALSKI_ALT_TOKEN: ${{ secrets.KOWALSKI_ALT_TOKEN }}
+        KOWALSKI_INSTANCE_TOKEN: ${{ secrets.KOWALSKI_INSTANCE_TOKEN }}
+        GLORIA_INSTANCE_TOKEN: ${{ secrets.GLORIA_INSTANCE_TOKEN }}
+        MELMAN_INSTANCE_TOKEN: ${{ secrets.MELMAN_INSTANCE_TOKEN }}
       run: |
         ./scope.py test


### PR DESCRIPTION
In light of failing Kowalski authentication in #410 (despite a successful local test), this PR adds new secrets to the workflow files in an attempt to ensure they get accessed by tests in subsequent PRs.

(Tests will likely fail due to the new penquins release)