### PR TITLE
Add interval between feature generation job submissions

### DIFF
--- a/tools/generate_features_job_submission.py
+++ b/tools/generate_features_job_submission.py
@@ -81,6 +81,12 @@ def parse_commandline():
         default=False,
         help="If set, reset the 'running' status of all tags",
     )
+    parser.add_argument(
+        "--submit_interval_minutes",
+        type=float,
+        default=1.0,
+        help="Time to wait between job submissions (minutes)",
+    )
 
     args = parser.parse_args()
 
@@ -149,7 +155,16 @@ def filter_completed(df, resultsDir, filename, reset_running=False):
     return df_toComplete, df_toRun
 
 
-def run_job(df, quadrant_index, resultsDir, filename, runParallel=False):
+def run_job(
+    df,
+    quadrant_index,
+    resultsDir,
+    filename,
+    runParallel=False,
+    submit_interval_minutes=1.0,
+):
+    # Don't hit kowalski with too many simultaneous queries
+    time.sleep(submit_interval_minutes * 60)
 
     row = df.iloc[quadrant_index]
     field, ccd, quadrant = int(row["field"]), int(row["ccd"]), int(row["quadrant"])
@@ -241,6 +256,7 @@ if __name__ == '__main__':
                         resultsDir,
                         filename,
                         runParallel=args.runParallel,
+                        submit_interval_minutes=args.submit_interval_minutes,
                     )
                     counter += 1
 
@@ -291,6 +307,7 @@ if __name__ == '__main__':
                     resultsDir,
                     filename,
                     runParallel=args.runParallel,
+                    submit_interval_minutes=args.submit_interval_minutes,
                 )
         else:
             print('Canceled loop submission.')

--- a/tools/generate_features_slurm.py
+++ b/tools/generate_features_slurm.py
@@ -446,6 +446,12 @@ if __name__ == "__main__":
         default="bhealy",
         help="HPC username",
     )
+    parser.add_argument(
+        "--submit_interval_minutes",
+        type=float,
+        default=1.0,
+        help="Time to wait between job submissions (minutes)",
+    )
 
     args = parser.parse_args()
 
@@ -645,7 +651,7 @@ if __name__ == "__main__":
     if not args.doSubmitLoop:
         if args.runParallel:
             fid.write(
-                '%s/generate_features_job_submission.py --dirname %s --filename %s --doSubmit --runParallel --max_instances %s --wait_time_minutes %s --user %s\n'
+                '%s/generate_features_job_submission.py --dirname %s --filename %s --doSubmit --runParallel --max_instances %s --wait_time_minutes %s --user %s --submit_interval_minutes %s\n'
                 % (
                     BASE_DIR / 'tools',
                     dirpath,
@@ -653,11 +659,12 @@ if __name__ == "__main__":
                     args.max_instances,
                     args.wait_time_minutes,
                     args.user,
+                    args.submit_interval_minutes,
                 )
             )
         else:
             fid.write(
-                '%s/generate_features_job_submission.py --dirname %s --filename %s --doSubmit --max_instances %s --wait_time_minutes %s --user %s\n'
+                '%s/generate_features_job_submission.py --dirname %s --filename %s --doSubmit --max_instances %s --wait_time_minutes %s --user %s --submit_interval_minutes %s\n'
                 % (
                     BASE_DIR / 'tools',
                     dirpath,
@@ -665,6 +672,7 @@ if __name__ == "__main__":
                     args.max_instances,
                     args.wait_time_minutes,
                     args.user,
+                    args.submit_interval_minutes,
                 )
             )
     else:


### PR DESCRIPTION
This PR adds a default 1-minute interval between feature generation job submissions. The intent of this interval is to slightly stagger kowalski queries to avoid the following errors: 

```
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='melman.caltech.edu', port=443): Max retries exceeded with url: /api/queries (Caused by ResponseError('too many 502 error responses'))
```

```
requests.exceptions.RetryError: HTTPSConnectionPool(host='melman.caltech.edu', port=443): Max retries exceeded with url: /api/queries (Caused by ResponseError('too many 502 error responses'))
```