### PR TITLE
Add support for inference slurm jobs

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1377,8 +1377,26 @@ feature_generation:
       - EAOV
   fields_to_run:
     # If this list is populated (example below), generate_features_job_submission.py will only run on the specified fields.
-    #- 296
-    #- 297
+    - 296
+    # - 297
+    # - 423
+    # - 424
+    # - 487
+    # - 488
+    # - 562
+    # - 563
+    # - 682
+    # - 683
+    # - 699
+    # - 700
+    # - 717
+    # - 718
+    # - 777
+    # - 778
+    # - 841
+    # - 842
+    # - 852
+    # - 853
   cesium_features:
     # Some features on this list are already computed by lcstats - these are commented below
     #
@@ -2105,3 +2123,27 @@ training:
       amsgrad: 0.0009407
       epsilon: 3.372e-8
       lr: 0.02622
+
+# Specify inference details here when running in parallel
+inference:
+  fields_to_run:
+    - 296
+    # - 297
+    # - 423
+    # - 424
+    # - 487
+    # - 488
+    # - 562
+    # - 563
+    # - 682
+    # - 683
+    # - 699
+    # - 700
+    # - 717
+    # - 718
+    # - 777
+    # - 778
+    # - 841
+    # - 842
+    # - 852
+    # - 853

--- a/scope.py
+++ b/scope.py
@@ -1170,7 +1170,8 @@ class Scope:
                     --algorithm='dnn' --feature_directory='generated_features'
         """
 
-        path = str(pathlib.Path(__file__).parent.absolute() / filename)
+        base_path = pathlib.Path(__file__).parent.absolute()
+        path = str(base_path / filename)
         group_path = (
             pathlib.Path(__file__).parent.absolute()
             / f'models_{algorithm}'
@@ -1214,7 +1215,7 @@ class Scope:
                     model_class_names_str += f'{tag} '
 
                 script.write(
-                    f'echo -n "Running inference..." && python tools/inference.py --paths_models {paths_models_str} --model_class_names {model_class_names_str} --field $1 --whole_field --flag_ids --scale_features {scale_features} --feature_directory {feature_directory} --period_suffix {period_suffix} --batch_size {batch_size} {addtl_args} && echo "done"\n'
+                    f'echo -n "Running inference..." && python {str(base_path)}/tools/inference.py --paths_models {paths_models_str} --model_class_names {model_class_names_str} --field $1 --whole_field --flag_ids --scale_features {scale_features} --feature_directory {feature_directory} --period_suffix {period_suffix} --batch_size {batch_size} {addtl_args} && echo "done"\n'
                 )
 
             elif algorithm in ['XGB', 'xgb', 'XGBoost', 'xgboost', 'XGBOOST']:
@@ -1232,7 +1233,7 @@ class Scope:
                     model_class_names_str += f'{tag} '
 
                 script.write(
-                    f'echo -n "Running inference..." && python tools/inference.py --paths_models {paths_models_str} --model_class_names {model_class_names_str} --scale_features {scale_features} --feature_directory {feature_directory} --period_suffix {period_suffix} --batch_size {batch_size} --xgb_model --field $1 --whole_field --flag_ids {addtl_args} && echo "done"\n'
+                    f'echo -n "Running inference..." && python {str(base_path)}/tools/inference.py --paths_models {paths_models_str} --model_class_names {model_class_names_str} --scale_features {scale_features} --feature_directory {feature_directory} --period_suffix {period_suffix} --batch_size {batch_size} --xgb_model --field $1 --whole_field --flag_ids {addtl_args} && echo "done"\n'
                 )
 
             else:

--- a/scope.py
+++ b/scope.py
@@ -1209,9 +1209,7 @@ class Scope:
                         [file for file in tag_file_gen], key=os.path.getctime
                     ).name
 
-                    paths_models_str += (
-                        f'models_{algorithm}/{group_name}/{tag}/{most_recent_file} '
-                    )
+                    paths_models_str += f'{str(base_path)}/models_{algorithm}/{group_name}/{tag}/{most_recent_file} '
                     model_class_names_str += f'{tag} '
 
                 script.write(

--- a/scope.py
+++ b/scope.py
@@ -1225,9 +1225,7 @@ class Scope:
                         [file for file in tag_file_gen], key=os.path.getctime
                     ).name
 
-                    paths_models_str += (
-                        f'models_{algorithm}/{group_name}/{tag}/{most_recent_file} '
-                    )
+                    paths_models_str += f'{str(base_path)}/models_{algorithm}/{group_name}/{tag}/{most_recent_file} '
                     model_class_names_str += f'{tag} '
 
                 script.write(

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -36,7 +36,7 @@ with open(config_path) as config_yaml:
 period_suffix = config['features']['info']['period_suffix']
 
 # Load training set
-trainingSetPath = config['training']['dataset']
+trainingSetPath = BASE_DIR + '/' + config['training']['dataset']
 if trainingSetPath.endswith('.parquet'):
     try:
         TRAINING_SET = read_parquet(trainingSetPath)

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -38,19 +38,19 @@ period_suffix = config['features']['info']['period_suffix']
 
 # Load training set
 trainingSetPath = BASE_DIR / config['training']['dataset']
-if trainingSetPath.endswith('.parquet'):
+if trainingSetPath.suffix == '.parquet':
     try:
         TRAINING_SET = read_parquet(trainingSetPath)
     except FileNotFoundError:
         warnings.warn('Training set file not found.')
         TRAINING_SET = []
-elif trainingSetPath.endswith('.h5'):
+elif trainingSetPath.suffix == '.h5':
     try:
         TRAINING_SET = read_hdf(trainingSetPath)
     except FileNotFoundError:
         warnings.warn('Training set file not found.')
         TRAINING_SET = []
-elif trainingSetPath.endswith('.csv'):
+elif trainingSetPath.suffix == '.csv':
     try:
         TRAINING_SET = pd.read_csv(trainingSetPath)
     except FileNotFoundError:
@@ -115,7 +115,7 @@ def clean_data(
     # file to store flagged ids and features with missing values
     if not whole_field:
         filename = (
-            BASE_DIR
+            str(BASE_DIR)
             + f"/preds_{algorithm}/field_"
             + str(field)
             + "/ccd_"
@@ -126,7 +126,7 @@ def clean_data(
         )
     else:
         filename = (
-            BASE_DIR
+            str(BASE_DIR)
             + f"/preds_{algorithm}/field_"
             + str(field)
             + f"/field_{field}_flagged.json"

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -25,18 +25,19 @@ import argparse
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 warnings.filterwarnings('ignore')
 
-BASE_DIR = os.path.dirname(__file__)
+# BASE_DIR = os.path.dirname(__file__)
+BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()
 JUST = 50
 
 
-config_path = pathlib.Path(__file__).parent.parent.absolute() / "config.yaml"
+config_path = BASE_DIR / "config.yaml"
 with open(config_path) as config_yaml:
     config = yaml.load(config_yaml, Loader=yaml.FullLoader)
 
 period_suffix = config['features']['info']['period_suffix']
 
 # Load training set
-trainingSetPath = BASE_DIR + '/' + config['training']['dataset']
+trainingSetPath = BASE_DIR / config['training']['dataset']
 if trainingSetPath.endswith('.parquet'):
     try:
         TRAINING_SET = read_parquet(trainingSetPath)
@@ -115,7 +116,7 @@ def clean_data(
     if not whole_field:
         filename = (
             BASE_DIR
-            + f"/../preds_{algorithm}/field_"
+            + f"/preds_{algorithm}/field_"
             + str(field)
             + "/ccd_"
             + str(ccd).zfill(2)
@@ -126,7 +127,7 @@ def clean_data(
     else:
         filename = (
             BASE_DIR
-            + f"/../preds_{algorithm}/field_"
+            + f"/preds_{algorithm}/field_"
             + str(field)
             + f"/field_{field}_flagged.json"
         )
@@ -255,19 +256,19 @@ def run_inference(
         algorithm = 'dnn'
 
     if field == 'specific_ids':
-        default_features_file = BASE_DIR + f"/../{feature_directory}/specific_ids"
+        default_features_file = str(BASE_DIR / f"{feature_directory}/specific_ids")
     else:
         field = int(field)
         # default file location for source ids
         if whole_field:
             default_features_file = (
-                BASE_DIR + f"/../{feature_directory}/field_" + str(field)
+                str(BASE_DIR) + f"/{feature_directory}/field_" + str(field)
             )
         else:
             if feature_directory == 'features':
                 default_features_file = (
-                    BASE_DIR
-                    + f"/../{feature_directory}/field_"
+                    str(BASE_DIR)
+                    + f"/{feature_directory}/field_"
                     + str(field)
                     + "/ccd_"
                     + str(ccd).zfill(2)
@@ -277,8 +278,8 @@ def run_inference(
                 )
             else:
                 default_features_file = (
-                    BASE_DIR
-                    + f"/../{feature_directory}/field_"
+                    str(BASE_DIR)
+                    + f"/{feature_directory}/field_"
                     + str(field)
                     + f"/{feature_file_prefix}_"
                     + "field_"
@@ -291,10 +292,10 @@ def run_inference(
                 )
 
     features_filename = kwargs.get("features_filename", default_features_file)
-    features_filename = os.path.join(BASE_DIR, features_filename)
+    # features_filename = os.path.join(str(BASE_DIR), features_filename)
 
     out_dir = os.path.join(
-        os.path.dirname(__file__), f"{BASE_DIR}/../preds_{algorithm}/"
+        os.path.dirname(__file__), f"{str(BASE_DIR)}/preds_{algorithm}/"
     )
 
     if not whole_field:

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -319,6 +319,9 @@ def run_inference(
     ccd_collection = np.array([])
     quad_collection = np.array([])
     filter_collection = np.array([])
+    gaia_edr3_id_collection = np.array([], dtype=np.int64)
+    allwise_id_collection = np.array([], dtype=np.int64)
+    ps1_dr1_id_collection = np.array([], dtype=np.int64)
     preds_collection = []
     filename = kwargs.get("output", default_outfile)
 
@@ -366,6 +369,18 @@ def run_inference(
         )
         quad_collection = np.concatenate(
             [quad_collection, features['quad'].astype("Int64").values]
+        )
+        gaia_edr3_id_collection = np.concatenate(
+            [
+                gaia_edr3_id_collection,
+                features['Gaia_EDR3___id'].fillna(0).astype("Int64"),
+            ]
+        )
+        allwise_id_collection = np.concatenate(
+            [allwise_id_collection, features['AllWISE___id'].fillna(0).astype("Int64")]
+        )
+        ps1_dr1_id_collection = np.concatenate(
+            [ps1_dr1_id_collection, features['PS1_DR1___id'].fillna(0).astype("Int64")]
         )
         try:
             filter_collection = np.concatenate(
@@ -595,10 +610,9 @@ def run_inference(
     if 'fritz_name' in features.columns:
         preds_df['obj_id'] = features['fritz_name']
 
-    preds_df['Gaia_EDR3___id'] = features['Gaia_EDR3___id'].fillna(0).astype("Int64")
-    preds_df['AllWISE___id'] = features['AllWISE___id'].fillna(0).astype("Int64")
-    preds_df['PS1_DR1___id'] = features['PS1_DR1___id'].fillna(0).astype("Int64")
-
+    preds_df['Gaia_EDR3___id'] = gaia_edr3_id_collection
+    preds_df['AllWISE___id'] = allwise_id_collection
+    preds_df['PS1_DR1___id'] = ps1_dr1_id_collection
     preds_df['ra'] = ra_collection
     preds_df['dec'] = dec_collection
     preds_df['period'] = period_collection

--- a/tools/run_inference_job_submission.py
+++ b/tools/run_inference_job_submission.py
@@ -108,7 +108,6 @@ if __name__ == '__main__':
         # Only run jobs from tags_remaining_to_run list
         run_job(
             field,
-            algorithm,
         )
 
     os.system(f"squeue -u {args.user}")

--- a/tools/run_inference_job_submission.py
+++ b/tools/run_inference_job_submission.py
@@ -49,9 +49,10 @@ def filter_completed(fields, algorithm):
     for field in fields:
         searchDir = BASE_DIR / f'preds_{algorithm}' / f'field_{field}'
         searchDir.mkdir(parents=True, exist_ok=True)
-        has_files = any(searchDir.iterdir())
+        generator = searchDir.iterdir()
+        has_parquet = [x.suffix == '.parquet' for x in generator]
 
-        if has_files:
+        if has_parquet:
             fields.remove(field)
 
     print('Models remaining to run: ', len(fields))

--- a/tools/run_inference_job_submission.py
+++ b/tools/run_inference_job_submission.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+import os
+import pathlib
+import argparse
+import yaml
+
+BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()
+
+# Read config file
+config_path = BASE_DIR / "config.yaml"
+with open(config_path) as config_yaml:
+    config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+
+
+def parse_commandline():
+    """
+    Parse the options given on the command-line.
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--dirname",
+        type=str,
+        default='inference',
+        help="Directory name for training slurm scripts",
+    )
+    parser.add_argument(
+        "--scriptname",
+        type=str,
+        default='get_all_preds.sh',
+        help="inference script name",
+    )
+    parser.add_argument(
+        "-f", "--filetype", default="slurm", help="Type of job submission file"
+    )
+    parser.add_argument(
+        "--user",
+        type=str,
+        default="bhealy",
+        help="HPC username",
+    )
+    parser.add_argument(
+        "--group_name",
+        type=str,
+        default=None,
+        help="Group name",
+    )
+    parser.add_argument(
+        "--algorithm",
+        type=str,
+        default='dnn',
+        help="dnn or xgb",
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def filter_completed(fields, algorithm):
+
+    for field in fields:
+        searchDir = BASE_DIR / f'preds_{algorithm}' / f'field_{field}'
+        searchDir.mkdir(parents=True, exist_ok=True)
+        has_files = any(searchDir.iterdir())
+
+        if has_files:
+            fields.remove(field)
+
+    print('Models remaining to run: ', len(fields))
+    return fields
+
+
+def run_job(field):
+    sbatchstr = f"sbatch --export=FID={field} {subfile}"
+    print(sbatchstr)
+    os.system(sbatchstr)
+
+
+if __name__ == '__main__':
+    # Parse command line
+    args = parse_commandline()
+
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+
+    scriptname = args.scriptname
+    filetype = args.filetype
+    dirname = args.dirname
+    sweep = args.sweep
+    reset_running = args.reset_running
+
+    slurmDir = str(BASE_DIR / dirname)
+    scriptpath = str(BASE_DIR / scriptname)
+
+    fields = config['inference']['fields_to_run']
+    group = args.group_name
+    algorithm = args.algorithm
+
+    subDir = os.path.join(slurmDir, filetype)
+    subfile = os.path.join(subDir, '%s.sub' % filetype)
+
+    fields_remaining = filter_completed(
+        fields,
+        algorithm,
+    )
+    njobs = len(fields_remaining)
+
+    for field in fields_remaining:
+        # Only run jobs from tags_remaining_to_run list
+        run_job(
+            field,
+            algorithm,
+        )
+
+    os.system(f"squeue -u {args.user}")
+
+    print('The final jobs in the run have been queued - breaking loop.')
+    print('Run "squeue -u <username>" to check status of remaining jobs.')

--- a/tools/run_inference_job_submission.py
+++ b/tools/run_inference_job_submission.py
@@ -40,12 +40,6 @@ def parse_commandline():
         help="HPC username",
     )
     parser.add_argument(
-        "--group_name",
-        type=str,
-        default=None,
-        help="Group name",
-    )
-    parser.add_argument(
         "--algorithm",
         type=str,
         default='dnn',
@@ -85,14 +79,11 @@ if __name__ == '__main__':
     scriptname = args.scriptname
     filetype = args.filetype
     dirname = args.dirname
-    sweep = args.sweep
-    reset_running = args.reset_running
 
     slurmDir = str(BASE_DIR / dirname)
     scriptpath = str(BASE_DIR / scriptname)
 
     fields = config['inference']['fields_to_run']
-    group = args.group_name
     algorithm = args.algorithm
 
     subDir = os.path.join(slurmDir, filetype)

--- a/tools/run_inference_job_submission.py
+++ b/tools/run_inference_job_submission.py
@@ -25,12 +25,6 @@ def parse_commandline():
         help="Directory name for training slurm scripts",
     )
     parser.add_argument(
-        "--scriptname",
-        type=str,
-        default='get_all_preds.sh',
-        help="inference script name",
-    )
-    parser.add_argument(
         "-f", "--filetype", default="slurm", help="Type of job submission file"
     )
     parser.add_argument(
@@ -76,12 +70,10 @@ if __name__ == '__main__':
 
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
-    scriptname = args.scriptname
     filetype = args.filetype
     dirname = args.dirname
 
     slurmDir = str(BASE_DIR / dirname)
-    scriptpath = str(BASE_DIR / scriptname)
 
     fields = config['inference']['fields_to_run']
     algorithm = args.algorithm


### PR DESCRIPTION
This PR adds code to run inference jobs on Expanse following the pattern of feature generation and training. A new section of the config file specifies the fields on which to run inference, and the other details are specified via `run_inference_slurm.py`. After running `slurm_submission.sub`, `run_inference_job_submission.py` checks for parquet files in each field of the predictions directory, queuing inference jobs for fields lacking results.