### PR TITLE
Fix get_lightcurves_via_coords for new penquins, add to tests

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -1770,6 +1770,7 @@ class Scope:
         """
         import uuid
         from tools import generate_features, get_quad_ids, get_features, inference
+        from scope.fritz import get_lightcurves_via_coords
 
         # Test feature generation
         with status("Test generate_features"):
@@ -1801,6 +1802,12 @@ class Scope:
                 / test_feature_directory
                 / f"field_{test_field}"
                 / f"{test_feature_filename}_field_{test_field}_ccd_{test_ccd}_quad_{test_quad}.parquet"
+            )
+
+        with status("Test get_lightcurves_via_coords"):
+            print()
+            _ = get_lightcurves_via_coords(
+                kowalski_instances=self.kowalski, ra=40.0, dec=50.0, radius=2.0
             )
 
         with status("Test get_cone_ids"):

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -71,7 +71,7 @@ BASE_URL = f"{config['fritz']['protocol']}://{config['fritz']['host']}/"
 MAX_ATTEMPTS = config['fritz']['max_attempts']
 SLEEP_TIME = config['fritz']['sleep_time']
 fritz_token = config['fritz']['token']
-default_catalog = config['kowalski']['collections']['sources']
+default_catalog = config['kowalski']['collections'].get('sources')
 
 
 def api(
@@ -145,6 +145,11 @@ def get_lightcurves_via_coords(
     Ncore=1,
     get_basic_data=False,
 ):
+
+    if catalog is None:
+        raise ValueError(
+            'No catalog specified. Please add one to config.yaml under kowalski: collectons: sources:'
+        )
 
     light_curve_ids = []
     query = {


### PR DESCRIPTION
This PR fixes the query in `get_lightcurves_via_coords` to work with penquins 2.3.1. The PR also sets the default source catalog using the config file rather than selecting the last catalog name in a list. A call to `get_lightcurves_via_coords` is added to the tests.