### PR TITLE
Overhaul combine_preds to facilitate Kowalski ingestion

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -1769,7 +1769,13 @@ class Scope:
         :return:
         """
         import uuid
-        from tools import generate_features, get_quad_ids, get_features, inference
+        from tools import (
+            generate_features,
+            get_quad_ids,
+            get_features,
+            inference,
+            combine_preds,
+        )
         from scope.fritz import get_lightcurves_via_coords
 
         # Test feature generation
@@ -2036,6 +2042,9 @@ class Scope:
                     period_suffix=period_suffix,
                     no_write_metadata=True,
                 )
+
+            with status("Test combine_preds"):
+                combine_preds.combine_preds(specific_field=0, save=False)
 
             with status("Test select_fritz_sample"):
                 print()

--- a/tools/combine_preds.py
+++ b/tools/combine_preds.py
@@ -5,11 +5,13 @@ import pathlib
 import argparse
 from scope.utils import read_parquet, write_parquet
 
-BASE_DIR = pathlib.Path(__file__).parent.absolute()
+BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()
 
 
 def combine_preds(
-    combined_preds_dirname='preds_dnn_xgb',
+    combined_preds_dirname: str = 'preds_dnn_xgb',
+    specific_field: str = None,
+    save: bool = True,
 ):
     """
     Combine DNN and XGB preds for ingestion into Kowalski
@@ -17,20 +19,25 @@ def combine_preds(
     :param combined_preds_dirname: directory name to use for combined preds (str)
 
     """
+    if specific_field is not None:
+        glob_input = specific_field
+    else:
+        glob_input = '*'
 
-    field_paths_dnn = [x for x in (BASE_DIR / 'preds_dnn').glob('field_*')]
+    field_paths_dnn = [x for x in (BASE_DIR / 'preds_dnn').glob(f'field_{glob_input}')]
     fields_dnn = [x.name for x in field_paths_dnn]
     fields_dnn_dict = {
         fields_dnn[i]: field_paths_dnn[i] for i in range(len(fields_dnn))
     }
 
-    field_paths_xgb = [x for x in (BASE_DIR / 'preds_xgb').glob('field_*')]
+    field_paths_xgb = [x for x in (BASE_DIR / 'preds_xgb').glob(f'field_{glob_input}')]
     fields_xgb = [x.name for x in field_paths_xgb]
     fields_xgb_dict = {
         fields_xgb[i]: field_paths_xgb[i] for i in range(len(fields_xgb))
     }
 
-    os.makedirs(BASE_DIR / combined_preds_dirname, exist_ok=True)
+    if save:
+        os.makedirs(BASE_DIR / combined_preds_dirname, exist_ok=True)
     counter = 0
     for field in fields_dnn_dict.keys():
         if field in fields_xgb_dict.keys():
@@ -49,9 +56,13 @@ def combine_preds(
             xgb_preds_new = xgb_preds[new_xgb_columns]
 
             combined_preds = pd.merge(dnn_preds, xgb_preds_new, on='_id')
-            write_parquet(
-                combined_preds, BASE_DIR / combined_preds_dirname / f"{field}.parquet"
-            )
+            print(len(combined_preds))
+            print(combined_preds.columns)
+            if save:
+                write_parquet(
+                    combined_preds,
+                    BASE_DIR / combined_preds_dirname / f"{field}.parquet",
+                )
 
 
 if __name__ == "__main__":
@@ -62,8 +73,21 @@ if __name__ == "__main__":
         default='preds_dnn_xgb',
         help="dirname in which to save combined preds",
     )
+    parser.add_argument(
+        "--specific_field",
+        type=str,
+        default=None,
+        help="specific field to combine preds (useful for testing)",
+    )
+    parser.add_argument(
+        "--doNotSave",
+        action='store_true',
+        help="if set, do not save results (useful for testing)",
+    )
     args = parser.parse_args()
 
     combine_preds(
         combined_preds_dirname=args.combined_preds_dirname,
+        specific_field=args.specific_field,
+        save=not args.doNotSave,
     )

--- a/tools/combine_preds.py
+++ b/tools/combine_preds.py
@@ -17,6 +17,8 @@ def combine_preds(
     Combine DNN and XGB preds for ingestion into Kowalski
 
     :param combined_preds_dirname: directory name to use for combined preds (str)
+    :param specific_field: number of specific field to run (str, useful for testing)
+    :param save: if True, save combined preds (bool, useful for testing)
 
     """
     if specific_field is not None:
@@ -56,8 +58,6 @@ def combine_preds(
             xgb_preds_new = xgb_preds[new_xgb_columns]
 
             combined_preds = pd.merge(dnn_preds, xgb_preds_new, on='_id')
-            print(len(combined_preds))
-            print(combined_preds.columns)
             if save:
                 write_parquet(
                     combined_preds,


### PR DESCRIPTION
Changes to `inference.py` have rendered `combine_preds.py` obsolete in its current form. This PR overhauls `combine_preds.py` to serve the new purpose of combining DNN and XGB prediction columns into one parquet file per field. This will facilitate a single-step ingestion of DNN/XGB predictions to Kowalski, which is important since Kowalski code does not currently support update existing entries with new fields.