### PR TITLE
Fix missing algorithm kwarg in slurm training script

### DIFF
--- a/tools/train_algorithm_slurm.py
+++ b/tools/train_algorithm_slurm.py
@@ -24,7 +24,7 @@ def parse_training_script(script_path):
     for line in lines:
         if 'scope.py train' in line:
             line_info = line.removeprefix('./scope.py train').split()
-            for arg in line_info:
+            for arg in line_info.copy():
                 if '--tag' in arg:
                     tag = arg.split('=')[1]
                     tags += [tag]


### PR DESCRIPTION
This PR makes a copy of training script line info so the code detects the algorithm kwarg. Previously it was removed owing to list mutability, so the algorithm would default to 'dnn' even when 'xgb' was specified.