### PR TITLE
Add script to automatically classify sources near GCN candidates

### DIFF
--- a/gcn_cronjob.py
+++ b/gcn_cronjob.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python
+from scope.fritz import api
+from datetime import datetime, timedelta
+import argparse
+import pathlib
+import yaml
+from tools.scope_download_gcn_sources import download_gcn_sources
+import os
+from scope.utils import read_parquet
+import numpy as np
+import warnings
+
+
+BASE_DIR = pathlib.Path(__file__).parent.absolute()
+NUM_PER_PAGE = 100
+
+config_path = BASE_DIR / "config.yaml"
+with open(config_path) as config_yaml:
+    config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+
+
+def query_gcn_events(
+    daysAgo=14.0,
+    query_group_ids: list = [],
+    post_group_ids: list = [1544],
+    days_range: float = 7.0,
+    radius_arcsec: float = 0.5,
+    save_filename: str = 'tools/fritzDownload/specific_ids_GCN_sources',
+    taxonomy_map: str = 'tools/fritz_mapper.json',
+    combined_preds_dirname: str = 'GCN_dnn_xgb',
+    dateobs: str = None,
+    p_threshold: float = 0.7,
+    username: str = 'bhealy',
+    generated_features_dirname: str = 'generated_features_gcn_sources',
+    partition: str = 'gpu-debug',
+    doNotPost: bool = False,
+    agg_method: str = 'mean',
+    dnn_preds_directory: str = 'GCN_dnn',
+    xgb_preds_directory: str = 'GCN_xgb',
+):
+
+    if dateobs is None:
+        utcnow = datetime.utcnow()
+        start_dt = utcnow - timedelta(days=daysAgo)
+        startDate = start_dt.strftime("%Y-%m-%dT%H:%M:%S")
+        print(f"Querying for GCN events occurring after {startDate}...")
+
+        nPerPage = NUM_PER_PAGE
+
+        params = {'startDate': startDate, 'numPerPage': nPerPage}
+        response = api('GET', '/api/gcn_event', data=params).json()
+
+        if response.get('status', 'error') == 'success':
+            data = response.get('data')
+            allMatches = data.get('totalMatches')
+            pages = int(np.ceil(allMatches / nPerPage))
+
+            print(f'Found {allMatches} events.')
+
+            gcn_events = []
+
+            # iterate over all pages in results
+            if (allMatches is not None) & (allMatches > 0):
+                print(f'Downloading {allMatches} events...')
+                for pageNum in range(1, pages + 1):
+                    print(f'Page {pageNum} of {pages}...')
+                    page_response = api(
+                        "GET",
+                        '/api/gcn_event',
+                        {
+                            "startDate": startDate,
+                            'numPerPage': NUM_PER_PAGE,
+                            'pageNumber': pageNum,
+                        },  # page numbers start at 1
+                    )
+                    page_data = page_response.json().get('data')
+                    events = page_data.get('events')
+                    gcn_events.extend([x for x in events])
+
+        else:
+            raise ValueError('Query error - no data returned.')
+
+    else:
+        gcn_events = [{"dateobs": dateobs}]
+
+    for event in gcn_events:
+        dateobs = event["dateobs"]
+        tags = event["tags"]
+
+        # Set group(s) for classifications
+        if ("GRB" in tags) | ("Fermi" in tags):
+            # Gamma Ray Bursts group on Fritz
+            post_group_ids = [48]
+        if "GW" in tags:
+            if 1544 not in post_group_ids:
+                # EM+GW group on Fritz
+                post_group_ids.append(1544)
+
+        post_group_ids_str = "".join([f"{x} " for x in post_group_ids]).strip()
+        print(f'Running for event {dateobs}...')
+
+        # Colons can confuse the file system; replace them for saving
+        save_dateobs = dateobs.replace(':', '-')
+
+        # Check for existing sources file
+        filepath = (
+            BASE_DIR
+            / f'tools/fritzDownload/specific_ids_GCN_sources.{save_dateobs}.parquet'
+        )
+        if filepath.exists():
+            existing_sources = read_parquet(filepath)
+            existing_ids = existing_sources['ztf_id'].values
+        else:
+            existing_ids = []
+
+        print(f'Downloading GCN sources for {dateobs}...')
+        ids = download_gcn_sources(
+            dateobs=dateobs,
+            group_ids=query_group_ids,
+            days_range=days_range,
+            radius_arcsec=radius_arcsec,
+            save_filename=save_filename,
+        )
+
+        try:
+            current_sources = read_parquet(filepath)
+            new_sources = current_sources.copy().set_index('ztf_id')
+
+            for id in existing_ids:
+                try:
+                    new_sources = new_sources.drop(id)
+                except KeyError:
+                    continue
+            new_sources.reset_index(inplace=True)
+        except FileNotFoundError:
+            new_sources = []
+
+        if len(new_sources) > 0:
+            has_new_sources = True
+            print(f"Event {dateobs} has {len(new_sources)} new sources.")
+        else:
+            has_new_sources = False
+            print(f"Event {dateobs} has no new sources.")
+
+        # if has_new_sources | rerun:
+        if ids is not None:
+            features_file = (
+                BASE_DIR
+                / f"{generated_features_dirname}/specific_ids/gen_gcn_features_{save_dateobs}_specific_ids.parquet"
+            )
+            if (not features_file.exists()) | (has_new_sources):
+                print("Generating features on Expanse...")
+                os.system(
+                    f"scp {filepath} {username}@login.expanse.sdsc.edu:/home/{username}/scope/tools/fritzDownload/."
+                )
+                os.system(
+                    f'ssh -t {username}@login.expanse.sdsc.edu \
+                    "source .bash_profile && \
+                    cd scope/{generated_features_dirname}/slurm && \
+                    sbatch --wait --export=DOBS={save_dateobs},DS={filepath.name} {partition}_slurm.sub"'
+                )
+                print("Finished generating features on Expanse.")
+
+                os.system(
+                    f"rsync -avh {username}@login.expanse.sdsc.edu:/home/{username}/scope/{generated_features_dirname} {BASE_DIR}/."
+                )
+
+            if features_file.exists():
+                features = read_parquet(features_file)
+
+                if len(features) > 0:
+                    preds_dnn_file = (
+                        BASE_DIR
+                        / f"preds_dnn/field_{save_dateobs}_specific_ids/field_{save_dateobs}_specific_ids.parquet"
+                    )
+                    preds_xgb_file = (
+                        BASE_DIR
+                        / f"preds_xgb/field_{save_dateobs}_specific_ids/field_{save_dateobs}_specific_ids.parquet"
+                    )
+                    preds_dnn_xgb_file = (
+                        BASE_DIR
+                        / f"{combined_preds_dirname}/{save_dateobs}/merged_GCN_sources_{save_dateobs}.parquet"
+                    )
+                    if (
+                        (not preds_dnn_xgb_file.exists())
+                        | (not preds_dnn_file.exists())
+                        | (not preds_xgb_file.exists())
+                        | has_new_sources
+                    ):
+                        print("Running DNN and XGB inference...")
+                        # DNN: use nobalance_DR16_DNN models
+                        os.system(
+                            f"{BASE_DIR}/get_all_preds_dnn_GCN.sh {save_dateobs}_specific_ids"
+                        )
+
+                        # XGB: use DR16_importance models
+                        os.system(
+                            f"{BASE_DIR}/get_all_preds_xgb_GCN.sh {save_dateobs}_specific_ids"
+                        )
+
+                        print(
+                            "Consolidating DNN and XGB classification results for Fritz..."
+                        )
+                        os.system(
+                            f"{BASE_DIR}/scope.py select_fritz_sample --fields='{save_dateobs}_specific_ids' --group='DR16' --algorithm='xgb' \
+                                --probability_threshold=0 --consol_filename='inference_results_{save_dateobs}' --al_directory='GCN' \
+                                --al_filename='GCN_sources_{save_dateobs}' --write_consolidation_results --select_top_n --doAllSources --write_csv"
+                        )
+
+                        os.system(
+                            f"{BASE_DIR}/scope.py select_fritz_sample --fields='{save_dateobs}_specific_ids' --group='nobalance_DR16_DNN' --algorithm='dnn' \
+                                --probability_threshold=0 --consol_filename='inference_results_{save_dateobs}' --al_directory='GCN' \
+                                --al_filename='GCN_sources_{save_dateobs}' --write_consolidation_results --select_top_n --doAllSources --write_csv"
+                        )
+
+                        print("Combining DNN and XGB preds...")
+                        os.system(
+                            f"{BASE_DIR}/tools/combine_preds.py --dateobs {save_dateobs} --combined_preds_dirname {combined_preds_dirname}/{save_dateobs} \
+                                  --merge_dnn_xgb --write_csv --p_threshold {p_threshold} --agg_method {agg_method} --dnn_directory {dnn_preds_directory} \
+                                  --xgb_directory {xgb_preds_directory}"
+                        )
+
+                    if not doNotPost:
+                        print(f"Uploading classifications with p > {p_threshold}.")
+                        os.system(
+                            f"{BASE_DIR}/tools/scope_upload_classification.py --file {combined_preds_dirname}/{save_dateobs}/merged_GCN_sources_{save_dateobs}.parquet \
+                                --classification read --taxonomy_map {taxonomy_map} --skip_phot --use_existing_obj_id --group_ids {post_group_ids_str} --radius_arcsec {radius_arcsec} \
+                                --p_threshold {p_threshold}"
+                        )
+
+                    print(f"Finished for {dateobs}.")
+
+                else:
+                    warnings.warn("No features returned.")
+
+            else:
+                warnings.warn("Features file does not exist.")
+        print()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--daysAgo",
+        default=14.0,
+        type=float,
+        help="Number of days before today to query GCN events",
+    )
+    parser.add_argument(
+        "--query_group_ids",
+        type=int,
+        nargs='+',
+        default=[],
+        help="group ids to query sources (all if not specified)",
+    )
+    parser.add_argument(
+        "--post_group_ids",
+        type=int,
+        nargs='+',
+        default=[1544],
+        help="group ids to post source classifications (EM+GW group if not specified)",
+    )
+    parser.add_argument(
+        "--days_range",
+        type=float,
+        default=7.0,
+        help="max days past event to search for sources",
+    )
+    parser.add_argument(
+        "--radius_arcsec",
+        type=float,
+        default=0.5,
+        help="radius around new sources to search for existing ZTF sources",
+    )
+    parser.add_argument(
+        "--save_filename",
+        type=str,
+        default='tools/fritzDownload/specific_ids_GCN_sources',
+        help="filename to save source ids/coordinates",
+    )
+    parser.add_argument(
+        "--taxonomy_map",
+        type=str,
+        default='tools/fritz_mapper.json',
+        help="path to taxonomy map for uploading classifications to Fritz",
+    )
+    parser.add_argument(
+        "--combined_preds_dirname",
+        type=str,
+        default='GCN_dnn_xgb',
+        help="dirname in which to save combined preds files",
+    )
+    parser.add_argument(
+        "--dateobs",
+        type=str,
+        default=None,
+        help="If querying specific dateobs, specify here to override daysAgo.",
+    )
+    parser.add_argument(
+        "--p_threshold",
+        type=float,
+        default=0.7,
+        help="minimum classification probability to post to Fritz",
+    )
+    parser.add_argument(
+        "--username",
+        type=str,
+        default='bhealy',
+        help="Username for compute resources (e.g. Expanse)",
+    )
+    parser.add_argument(
+        "--generated_features_dirname",
+        type=str,
+        default='generated_features_GCN_sources',
+        help="dirname containing generated GCN source features",
+    )
+    parser.add_argument(
+        "--partition",
+        type=str,
+        default='gpu-debug',
+        help="name of compute partition on which to run feature generation",
+    )
+    parser.add_argument(
+        "--doNotPost",
+        action='store_true',
+        help="If set, run analysis but do not post classifications. Useful for testing",
+    )
+    parser.add_argument(
+        "--agg_method",
+        type=str,
+        default='mean',
+        help="Aggregation method for classification probabilities (mean or max)",
+    )
+    parser.add_argument(
+        "--dnn_preds_directory",
+        type=str,
+        default='GCN_dnn',
+        help="dirname in which dnn preds are saved",
+    )
+    parser.add_argument(
+        "--xgb_preds_directory",
+        type=str,
+        default='GCN_xgb',
+        help="dirname in which xgb preds preds are saved",
+    )
+
+    args = parser.parse_args()
+
+    query_gcn_events(
+        daysAgo=args.daysAgo,
+        query_group_ids=args.query_group_ids,
+        post_group_ids=args.post_group_ids,
+        days_range=args.days_range,
+        radius_arcsec=args.radius_arcsec,
+        save_filename=args.save_filename,
+        taxonomy_map=args.taxonomy_map,
+        combined_preds_dirname=args.combined_preds_dirname,
+        dateobs=args.dateobs,
+        p_threshold=args.p_threshold,
+        username=args.username,
+        generated_features_dirname=args.generated_features_dirname,
+        partition=args.partition,
+        doNotPost=args.doNotPost,
+        agg_method=args.agg_method,
+        dnn_preds_directory=args.dnn_preds_directory,
+        xgb_preds_directory=args.xgb_preds_directory,
+    )

--- a/scope.py
+++ b/scope.py
@@ -1485,15 +1485,13 @@ class Scope:
         if fields in ['all', 'All', 'ALL']:
             gen_fields = os.walk(preds_path)
             fields = [x for x in gen_fields][0][1]
-        elif fields == 'specific_ids':
-            fields = ['field_specific_ids']
+            print(f'Generating Fritz sample from {len(fields)} fields:')
+        elif 'specific_ids' in fields:
+            fields = [f'field_{fields}']
+            print('Generating Fritz sample from specific ids across multiple fields:')
         else:
             fields = [f'field_{f}' for f in fields]
-
-        if 'field_specific_ids' not in fields:
             print(f'Generating Fritz sample from {len(fields)} fields:')
-        else:
-            print('Generating Fritz sample from specific ids across multiple fields:')
 
         column_nums = []
 

--- a/tools/combine_preds.py
+++ b/tools/combine_preds.py
@@ -3,6 +3,8 @@ import pandas as pd
 import os
 import pathlib
 import argparse
+import numpy as np
+import json
 from scope.utils import read_parquet, write_parquet
 
 BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()
@@ -11,7 +13,14 @@ BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()
 def combine_preds(
     combined_preds_dirname: str = 'preds_dnn_xgb',
     specific_field: str = None,
+    dateobs: str = None,
+    merge_dnn_xgb: bool = False,
+    dnn_directory: str = 'preds_dnn',
+    xgb_directory: str = 'preds_xgb',
     save: bool = True,
+    write_csv: bool = False,
+    agg_method: str = 'mean',
+    p_threshold: float = 0.7,
 ):
     """
     Combine DNN and XGB preds for ingestion into Kowalski
@@ -21,19 +30,32 @@ def combine_preds(
     :param save: if True, save combined preds (bool, useful for testing)
 
     """
-    if specific_field is not None:
-        glob_input = specific_field
-    else:
-        glob_input = '*'
+    if (specific_field is not None) & (dateobs is not None):
+        raise ValueError("Please specify only one of --specific_field and --dateobs.")
 
-    field_paths_dnn = [x for x in (BASE_DIR / 'preds_dnn').glob(f'field_{glob_input}')]
-    fields_dnn = [x.name for x in field_paths_dnn]
+    if specific_field is not None:
+        glob_input = f"field_{specific_field}"
+    elif dateobs is not None:
+        if ':' in dateobs:
+            dateobs.replace(':', '-')
+        glob_input = f"GCN_sources_{dateobs}"
+    else:
+        glob_input = 'field_*[!specific_ids]'
+
+    field_paths_dnn = [x for x in (BASE_DIR / dnn_directory).glob(glob_input)]
+    if dateobs is not None:
+        fields_dnn = [x.name for x in field_paths_dnn if dateobs in x.name]
+    else:
+        fields_dnn = [x.name for x in field_paths_dnn]
     fields_dnn_dict = {
         fields_dnn[i]: field_paths_dnn[i] for i in range(len(fields_dnn))
     }
 
-    field_paths_xgb = [x for x in (BASE_DIR / 'preds_xgb').glob(f'field_{glob_input}')]
-    fields_xgb = [x.name for x in field_paths_xgb]
+    field_paths_xgb = [x for x in (BASE_DIR / xgb_directory).glob(glob_input)]
+    if dateobs is not None:
+        fields_xgb = [x.name for x in field_paths_xgb if dateobs in x.name]
+    else:
+        fields_xgb = [x.name for x in field_paths_xgb]
     fields_xgb_dict = {
         fields_xgb[i]: field_paths_xgb[i] for i in range(len(fields_xgb))
     }
@@ -41,6 +63,7 @@ def combine_preds(
     if save:
         os.makedirs(BASE_DIR / combined_preds_dirname, exist_ok=True)
     counter = 0
+    print(f"Processing {len(fields_dnn_dict)} fields/files...")
     for field in fields_dnn_dict.keys():
         if field in fields_xgb_dict.keys():
             try:
@@ -51,18 +74,76 @@ def combine_preds(
                 continue
 
             counter += 1
-            dnn_columns = [x for x in dnn_preds.columns]
-            dnn_columns.remove('_id')
-            xgb_columns = [x for x in xgb_preds.columns]
-            new_xgb_columns = [x for x in xgb_columns if (x not in dnn_columns)]
-            xgb_preds_new = xgb_preds[new_xgb_columns]
 
-            combined_preds = pd.merge(dnn_preds, xgb_preds_new, on='_id')
+            dnn_columns = [x for x in dnn_preds.columns]
+            xgb_columns = [x for x in xgb_preds.columns]
+
+            if not merge_dnn_xgb:
+                id_col = '_id' if dateobs is None else 'obj_id'
+
+                dnn_columns.remove(id_col)
+
+                new_xgb_columns = [x for x in xgb_columns if (x not in dnn_columns)]
+                xgb_preds_new = xgb_preds[new_xgb_columns]
+
+                preds_to_save = pd.merge(dnn_preds, xgb_preds_new, on=id_col)
+                meta_dict = None
+            else:
+                field = f"merged_{field}"
+
+                merged_preds = pd.merge(dnn_preds, xgb_preds, on='obj_id')
+                shared_obj_ids = merged_preds['obj_id'].values
+
+                # Rename e.g. vnv_dnn and vnv_xgb both to vnv
+                dnn_rename_mapper = {
+                    c: c.split('_')[0] for c in dnn_columns if '_dnn' in c
+                }
+                xgb_rename_mapper = {
+                    c: c.split('_')[0] for c in xgb_columns if '_xgb' in c
+                }
+
+                dnn_preds = dnn_preds.rename(dnn_rename_mapper, axis=1)
+                xgb_preds = xgb_preds.rename(xgb_rename_mapper, axis=1)
+
+                combined_preds = pd.concat([dnn_preds, xgb_preds])
+                combined_columns = [x for x in combined_preds.columns if '_id' not in x]
+                pred_columns = np.array(
+                    [x for x in combined_columns if x not in ['ra', 'dec', 'period']]
+                )
+
+                if agg_method not in ['mean', 'max']:
+                    raise ValueError(
+                        "Currently supported aggregation methods are 'mean', 'max'."
+                    )
+
+                agg_dct = {c: agg_method for c in combined_columns}
+                grouped_preds = combined_preds.groupby(['obj_id', 'survey_id'])
+                aggregated_preds = grouped_preds.agg(agg_dct)
+
+                preds_to_save = aggregated_preds.loc[shared_obj_ids].reset_index()
+
+                meta_dict = {}
+                for _, row in preds_to_save.iterrows():
+                    gt_threshold = (row[pred_columns] > p_threshold).values
+                    new_entry = {row['obj_id']: (pred_columns[gt_threshold]).tolist()}
+                    meta_dict.update(new_entry)
+
             if save:
                 write_parquet(
-                    combined_preds,
+                    preds_to_save,
                     BASE_DIR / combined_preds_dirname / f"{field}.parquet",
                 )
+                if write_csv:
+                    preds_to_save.to_csv(
+                        BASE_DIR / combined_preds_dirname / f"{field}.csv", index=False
+                    )
+                if meta_dict is not None:
+                    with open(
+                        BASE_DIR / combined_preds_dirname / f"{field}_meta.json", 'w'
+                    ) as f:
+                        json.dump(meta_dict, f)
+
+    return preds_to_save
 
 
 if __name__ == "__main__":
@@ -80,14 +161,61 @@ if __name__ == "__main__":
         help="specific field to combine preds (useful for testing)",
     )
     parser.add_argument(
+        "--dateobs",
+        type=str,
+        default=None,
+        help="GCN dateobs if not running on field/fields",
+    )
+    parser.add_argument(
+        "--merge_dnn_xgb",
+        action='store_true',
+        help="if set, combine dnn and xgb classifications instead of keeping separate",
+    )
+    parser.add_argument(
+        "--dnn_directory",
+        type=str,
+        default='preds_dnn',
+        help="dirname in which dnn preds are saved",
+    )
+    parser.add_argument(
+        "--xgb_directory",
+        type=str,
+        default='preds_xgb',
+        help="dirname in which xgb preds preds are saved",
+    )
+    parser.add_argument(
         "--doNotSave",
         action='store_true',
         help="if set, do not save results (useful for testing)",
+    )
+    parser.add_argument(
+        "--write_csv",
+        action='store_true',
+        help="if set, save CSV file in addition to parquet",
+    )
+    parser.add_argument(
+        "--agg_method",
+        type=str,
+        default='mean',
+        help="Aggregation method for classification probabilities (mean or max)",
+    )
+    parser.add_argument(
+        "--p_threshold",
+        type=float,
+        default=0.7,
+        help="Minimum probability to add classification to metadata file",
     )
     args = parser.parse_args()
 
     combine_preds(
         combined_preds_dirname=args.combined_preds_dirname,
         specific_field=args.specific_field,
+        dateobs=args.dateobs,
+        merge_dnn_xgb=args.merge_dnn_xgb,
+        dnn_directory=args.dnn_directory,
+        xgb_directory=args.xgb_directory,
         save=not args.doNotSave,
+        write_csv=args.write_csv,
+        agg_method=args.agg_method,
+        p_threshold=args.p_threshold,
     )

--- a/tools/fritz_mapper.json
+++ b/tools/fritz_mapper.json
@@ -1,0 +1,226 @@
+{
+    "vnv":
+        {"fritz_label": "variable",
+          "taxonomy_id": 1017
+        },
+
+    "pnp":
+        {"fritz_label": "periodic",
+          "taxonomy_id": 1017
+        },
+
+    "puls":
+        {"fritz_label": "Pulsating",
+          "taxonomy_id": 1015
+        },
+
+    "rrlyr":
+        {"fritz_label": "RR Lyrae",
+          "taxonomy_id": 1015
+        },
+
+    "ceph":
+        {"fritz_label": "Cepheid",
+          "taxonomy_id": 1015
+        },
+
+    "mp":
+        {"fritz_label": "multi periodic",
+          "taxonomy_id": 1017
+        },
+
+    "sin":
+        {"fritz_label": "sinusoidal",
+          "taxonomy_id": 1017
+        },
+
+    "nonvar":
+        {"fritz_label": "non-variable",
+          "taxonomy_id": 1017
+        },
+
+    "bogus":
+        {"fritz_label": "bogus",
+          "taxonomy_id": 1017
+        },
+
+    "bright":
+        {"fritz_label": "bright star",
+          "taxonomy_id": 1017
+        },
+
+    "longt":
+        {"fritz_label": "long timescale",
+          "taxonomy_id": 1017
+        },
+
+    "i":
+        {"fritz_label": "irregular",
+          "taxonomy_id": 1017
+        },
+
+    "e":
+        {"fritz_label": "eclipsing",
+          "taxonomy_id": 1017
+        },
+
+    "ew":
+        {"fritz_label": "EW",
+          "taxonomy_id": 1017
+        },
+
+    "fla":
+        {"fritz_label": "flaring",
+          "taxonomy_id": 1017
+        },
+
+    "bis":
+        {"fritz_label": "Eclipsing",
+          "taxonomy_id": 1015
+        },
+
+    "emsms":
+        {"fritz_label": "detached MS-MS",
+          "taxonomy_id": 1015
+        },
+
+    "wuma":
+        {"fritz_label": "W Ursae Maj",
+          "taxonomy_id": 1015
+        },
+
+    "rrab":
+        {"fritz_label": "RRab",
+          "taxonomy_id": 1015
+        },
+
+    "rrc":
+        {"fritz_label": "RRc",
+          "taxonomy_id": 1015
+        },
+
+    "dscu":
+        {"fritz_label": "Delta Scuti",
+          "taxonomy_id": 1015
+        },
+
+    "rrd":
+        {"fritz_label": "RRd",
+          "taxonomy_id": 1015
+        },
+
+    "ceph2":
+        {"fritz_label": "Population II Cepheid",
+          "taxonomy_id": 1015
+        },
+
+    "rscvn":
+        {"fritz_label": "RS CVn",
+        "taxonomy_id": 1015
+        },
+
+    "eb":
+        {"fritz_label": "EB",
+          "taxonomy_id": 1017
+        },
+
+    "blyr":
+        {"fritz_label": "Beta Lyrae",
+          "taxonomy_id": 1015
+        },
+
+    "saw":
+        {"fritz_label": "sawtooth",
+          "taxonomy_id": 1017
+        },
+
+    "ea":
+        {"fritz_label": "EA",
+          "taxonomy_id": 1017
+        },
+
+    "yso":
+        {"fritz_label": "YSO",
+          "taxonomy_id": 1015
+        },
+
+    "wp":
+        {"fritz_label": "wrong period",
+          "taxonomy_id": 1017
+        },
+
+    "agn":
+        {"fritz_label": "AGN",
+          "taxonomy_id": 1015
+        },
+
+    "lpv":
+        {"fritz_label": "LPV",
+          "taxonomy_id": 1015
+        },
+
+    "mir":
+        {"fritz_label": "Mira",
+          "taxonomy_id": 1015
+        },
+
+    "hp":
+        {"fritz_label": "half period",
+          "taxonomy_id": 1017
+        },
+
+    "srv":
+        {"fritz_label": "Semiregular",
+          "taxonomy_id": 1015
+        },
+
+    "osarg":
+        {"fritz_label": "OSARG",
+          "taxonomy_id": 1015
+        },
+
+    "el":
+        {"fritz_label": "ellipsoidal",
+          "taxonomy_id": 1017
+        },
+
+    "blend":
+      {"fritz_label": "blend",
+        "taxonomy_id": 1017
+      },
+
+    "cv":
+      {"fritz_label": "Cataclysmic",
+        "taxonomy_id": 1015
+      },
+
+    "wvir":
+      {"fritz_label": "W Vir",
+        "taxonomy_id": 1015
+      },
+
+    "rrblz":
+      {"fritz_label": "Blazhko",
+        "taxonomy_id": 1015
+      },
+
+    "blher":
+      {"fritz_label": "BL Her",
+        "taxonomy_id": 1015
+      },
+
+    "dip":
+      {"fritz_label": "dipping",
+        "taxonomy_id": 1017
+      },
+
+    "dp":
+      {"fritz_label": "double period",
+        "taxonomy_id": 1017
+      },
+
+    "ext":
+      {"fritz_label": "extended",
+        "taxonomy_id": 1017
+      }
+    }

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -255,8 +255,12 @@ def run_inference(
     else:
         algorithm = 'dnn'
 
-    if field == 'specific_ids':
-        default_features_file = str(BASE_DIR / f"{feature_directory}/specific_ids")
+    if type(field) == str:
+        if 'specific_ids' in field:
+            default_features_file = str(
+                BASE_DIR
+                / f"{feature_directory}/specific_ids/gen_gcn_features_{field}.parquet"
+            )
     else:
         field = int(field)
         # default file location for source ids
@@ -292,7 +296,6 @@ def run_inference(
                 )
 
     features_filename = kwargs.get("features_filename", default_features_file)
-    # features_filename = os.path.join(str(BASE_DIR), features_filename)
 
     out_dir = os.path.join(
         os.path.dirname(__file__), f"{str(BASE_DIR)}/preds_{algorithm}/"
@@ -327,7 +330,9 @@ def run_inference(
 
     os.makedirs(os.path.dirname(filename), exist_ok=True)
     if os.path.isfile(f'{filename}.parquet'):
-        raise FileExistsError('Preds file for this field (/ccd/quad) already exists.')
+        warnings.warn(
+            'Preds file for this field (/ccd/quad) already exists. Overwriting...'
+        )
 
     ts = time.time()
     DS = ds.dataset(features_filename, format='parquet')


### PR DESCRIPTION
This PR adds a script (`gcn_cronjob.py`) that automatically classifies light curves within 0.5 arcsec (by default) of candidates for GCN events. The script queries all GCN events within the last 14 days, identifies any new sources, runs feature generation on Expanse, pulls those results and runs inference locally, consolidates predictions, and uploads DNN/XGB classifications above a mean probability threshold of 0.7. A metadata file for each event lists sources and their classifications passing the threshold.

This script can be run as a cron job, e.g. on the hour:
```
0 * * * * ~/miniforge3/envs/scope-env/bin/python ~/scope/gcn_cronjob.py > ~/scope/log_gcn_cronjob.txt 2>&1
```

A future PR will allow light curve plots associated with the classifications to be posted as comments.