### PR TITLE
Fix bugs for single dateobs, empty classification list

### DIFF
--- a/gcn_cronjob.py
+++ b/gcn_cronjob.py
@@ -72,8 +72,8 @@ def query_gcn_events(
                             'numPerPage': NUM_PER_PAGE,
                             'pageNumber': pageNum,
                         },  # page numbers start at 1
-                    )
-                    page_data = page_response.json().get('data')
+                    ).json()
+                    page_data = page_response.get('data')
                     events = page_data.get('events')
                     gcn_events.extend([x for x in events])
 
@@ -81,7 +81,13 @@ def query_gcn_events(
             raise ValueError('Query error - no data returned.')
 
     else:
-        gcn_events = [{"dateobs": dateobs}]
+        response = api('GET', f'/api/gcn_event/{dateobs}').json()
+        if response.get('status', 'error') == 'success':
+            event = response.get('data')
+            gcn_events = [event]
+        else:
+            warnings.warn("Unsuccessful query.")
+            return
 
     for event in gcn_events:
         dateobs = event["dateobs"]

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -114,6 +114,11 @@ def upload_classification(
         all_sources = read_parquet(file)
     else:
         raise TypeError('Input file must be csv, h5 or parquet format.')
+
+    if len(all_sources) == 0:
+        warnings.warn("No sources to upload.")
+        return
+
     columns = all_sources.columns
     sources = all_sources.copy()
 


### PR DESCRIPTION
This PR fixes `gcn_cronjob.py` bugs that raised errors for single-dateobs querying and uploading empty classification lists.