### PR TITLE
Fix cronjob issues specific to running in cron environment

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -1150,6 +1150,8 @@ class Scope:
         feature_directory: str = 'features',
         write_csv: bool = False,
         batch_size: int = 100000,
+        use_custom_python: bool = False,
+        path_to_python: str = '~/miniforge3/envs/scope-env/bin/python',
         **kwargs,
     ):
         """
@@ -1162,6 +1164,8 @@ class Scope:
         :param feature_directory: name of directory containing downloaded or generated features (str)
         :param write_csv: if True, write CSV file in addition to parquet (bool)
         :param batch_size: batch size to use when reading feature files (int)
+        :param use_custom_python: if True, the call to inference.py will be preceded by a specific path to python (bool)
+        :param path_to_python: if use_custom_python is set (e.g. for a cron job), path to custom python installation (str)
 
         :return:
         Saves shell script to use when running inference
@@ -1190,6 +1194,9 @@ class Scope:
             'period_suffix', self.config['features']['info']['period_suffix']
         )
 
+        if not use_custom_python:
+            path_to_python = ''
+
         with open(path, 'x') as script:
             script.write('#!/bin/bash\n')
             script.write(
@@ -1213,7 +1220,7 @@ class Scope:
                     model_class_names_str += f'{tag} '
 
                 script.write(
-                    f'echo -n "Running inference..." && python {str(base_path)}/tools/inference.py --paths_models {paths_models_str} --model_class_names {model_class_names_str} --field $1 --whole_field --flag_ids --scale_features {scale_features} --feature_directory {feature_directory} --period_suffix {period_suffix} --batch_size {batch_size} {addtl_args} && echo "done"\n'
+                    f'echo -n "Running inference..." && {path_to_python} {str(base_path)}/tools/inference.py --paths_models {paths_models_str} --model_class_names {model_class_names_str} --field $1 --whole_field --flag_ids --scale_features {scale_features} --feature_directory {feature_directory} --period_suffix {period_suffix} --batch_size {batch_size} {addtl_args} && echo "done"\n'
                 )
 
             elif algorithm in ['XGB', 'xgb', 'XGBoost', 'xgboost', 'XGBOOST']:
@@ -1229,7 +1236,7 @@ class Scope:
                     model_class_names_str += f'{tag} '
 
                 script.write(
-                    f'echo -n "Running inference..." && python {str(base_path)}/tools/inference.py --paths_models {paths_models_str} --model_class_names {model_class_names_str} --scale_features {scale_features} --feature_directory {feature_directory} --period_suffix {period_suffix} --batch_size {batch_size} --xgb_model --field $1 --whole_field --flag_ids {addtl_args} && echo "done"\n'
+                    f'echo -n "Running inference..." && {path_to_python} {str(base_path)}/tools/inference.py --paths_models {paths_models_str} --model_class_names {model_class_names_str} --scale_features {scale_features} --feature_directory {feature_directory} --period_suffix {period_suffix} --batch_size {batch_size} --xgb_model --field $1 --whole_field --flag_ids {addtl_args} && echo "done"\n'
                 )
 
             else:


### PR DESCRIPTION
The cron environment does not have access to the same paths and environment variables as a login shell. This PR updates `gcn_cronjob.py` to run successfully given these differences. Most notably, the path to the scope environment's python installation (with all required packages installed) can now be specified. Some background info is added as comments here, with more documentation planned for a future PR.