### PR TITLE
Update default GCN cronjob daysAgo

### DIFF
--- a/gcn_cronjob.py
+++ b/gcn_cronjob.py
@@ -251,7 +251,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         "--daysAgo",
-        default=14.0,
+        default=7.0,
         type=float,
         help="Number of days before today to query GCN events",
     )


### PR DESCRIPTION
This PR updates the default `daysAgo` argument in the GCN cronjob from 14 to 7 days, so the code will only consider events happening within the last 7 days. This adds consistency with another argument that determines how far forward to search for sources (`days_range`), which is already 7 days by default. This means that once the cron job runs once, GCN events happening prior to 7 days ago will not receive any new sources/classifications under the current defaults.

Making this change reduces the run time of each cron job and removes unnecessary calls to the Fritz API. Usually `daysAgo` and `days_range` should be the same, except for cases where the cron job hasn't run in a while. In those cases, `daysAgo` may be somewhat greater than `days_range`.