### PR TITLE
Add scanner guide to docs index

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,4 +7,5 @@ ZTF Variable Source Classification Project
    field_guide
    usage
    developer
+   scanner
    license

--- a/doc/scanner.md
+++ b/doc/scanner.md
@@ -1,4 +1,4 @@
-# SCoPe Guide for Fritz Scanners
+# Guide for Fritz Scanners
 This page is a guide the SCoPe classification process. It contains sections on the classification taxonomies we use, definitions of each classification that may be posted to Fritz, An explanation of the binary classifier algorithms we train and the workflow we run on transient candidates, and plots of each classifer's current precision and recall scores.
 
 ## Two classification taxonomies


### PR DESCRIPTION
This PR adds the new scanner guide to the documentation index so it can be reached more easily.