### PR TITLE
Add phase-folding argument to gcn_cronjob.py classification uploads

### DIFF
--- a/gcn_cronjob.py
+++ b/gcn_cronjob.py
@@ -275,7 +275,7 @@ def query_gcn_events(
                         os.system(
                             f"{path_to_python} {BASE_DIR}/tools/scope_upload_classification.py --file {BASE_DIR}/{combined_preds_dirname}/{save_dateobs}/merged_GCN_sources_{save_dateobs}.parquet \
                                 --classification read --taxonomy_map {BASE_DIR}/{taxonomy_map} --skip_phot --use_existing_obj_id --group_ids {post_group_ids_str} --radius_arcsec {radius_arcsec} \
-                                --p_threshold {p_threshold} --post_phot_as_comment"
+                                --p_threshold {p_threshold} --post_phot_as_comment --post_phasefolded_phot"
                         )
 
                     print(f"Finished for {dateobs}.")


### PR DESCRIPTION
This PR adds phase-folded light curves to the plots posted as comments by `gcn_cronjob.py`.