### PR TITLE
Plot DNN architecture during training

### DIFF
--- a/.requirements/doc.txt
+++ b/.requirements/doc.txt
@@ -18,3 +18,4 @@ numpy>=1.23,<1.24
 cesium>=0.11.1
 xgboost>=1.7.5
 seaborn>=0.12.2
+pydot>=1.4.2

--- a/scope.py
+++ b/scope.py
@@ -845,6 +845,21 @@ class Scope:
                     amsgrad=amsgrad,
                 )
 
+            if plot:
+                tf.keras.utils.plot_model(
+                    classifier.model,
+                    to_file=self.base_path / "DNN.pdf",
+                    show_shapes=True,
+                    show_dtype=False,
+                    show_layer_names=False,
+                    rankdir="TB",
+                    expand_nested=False,
+                    dpi=300,
+                    layer_range=None,
+                    show_layer_activations=True,
+                    show_trainable=False,
+                )
+
             if verbose:
                 print(classifier.model.summary())
 


### PR DESCRIPTION
This PR adds code to save a plot of the DNN architecture using `tf.keras.utils.plot_model`. It also adds a `pydot` requirement needed for this code to work.