### PR TITLE
Only apply balancing to training set, leaving val and test sets unchanged

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -920,6 +920,8 @@ class Scope:
             X_test = ds.df_ds.loc[indexes['test']][features]
             y_test = ds.target[indexes['test']]
 
+            scale_pos_weight = class_weight[1] / class_weight[0]
+
             # Add code to train XGB algorithm
             classifier = XGB(name=tag)
             classifier.setup(
@@ -932,6 +934,7 @@ class Scope:
                 eval_metric=eval_metric,
                 early_stopping_rounds=early_stopping_rounds,
                 num_boost_round=num_boost_round,
+                scale_pos_weight=scale_pos_weight,
             )
             classifier.train(
                 X_train,

--- a/scope/xgb.py
+++ b/scope/xgb.py
@@ -28,6 +28,7 @@ class XGB(AbstractClassifier):
         eval_metric='auc',
         early_stopping_rounds=10,
         num_boost_round=999,
+        scale_pos_weight=1.0,
         **kwargs,
     ):
         #  removed for now:
@@ -42,6 +43,7 @@ class XGB(AbstractClassifier):
             'colsample_bytree': colsample_bytree,
             'objective': objective,
             'eval_metric': eval_metric,
+            'scale_pos_weight': scale_pos_weight,
         }
 
         self.meta['early_stopping_rounds'] = early_stopping_rounds


### PR DESCRIPTION
This PR changes the behavior of the `balance` hyperparameter so that only the training set is modified. The validation and test sets are left unchanged regardless of the desired balance to ensure that stats like precision and recall can be compared to each other across all training runs. 

Additionally, the `weight_per_class` parameter can now be used during XGB training by setting the `scale_pos_weight` parameter under the hood.