### PR TITLE
Update confusion matrix and feature importance plots

### DIFF
--- a/scope.py
+++ b/scope.py
@@ -728,7 +728,8 @@ class Scope:
 
         # confusion matrix plotting parameters:
         cm_include_count = kwargs.get("cm_include_count", False)
-        cm_include_percent = kwargs.get("cm_include_percent", False)
+        cm_include_percent = kwargs.get("cm_include_percent", True)
+        annotate_scores = kwargs.get("annotate_scores", False)
 
         # seed: random seed
         seed = train_config_xgb['other_training_params'].get('seed', 42)
@@ -1037,6 +1038,7 @@ class Scope:
                 plot=plot,
                 cm_include_count=cm_include_count,
                 cm_include_percent=cm_include_percent,
+                annotate_scores=annotate_scores,
             )
 
             return time_tag

--- a/scope.py
+++ b/scope.py
@@ -726,6 +726,10 @@ class Scope:
         colsample_bytree_stop = colsample_bytree_config[1]
         colsample_bytree_step = colsample_bytree_config[2]
 
+        # confusion matrix plotting parameters:
+        cm_include_count = kwargs.get("cm_include_count", False)
+        cm_include_percent = kwargs.get("cm_include_percent", False)
+
         # seed: random seed
         seed = train_config_xgb['other_training_params'].get('seed', 42)
 
@@ -1031,6 +1035,8 @@ class Scope:
                 output_path=str(output_path / tag),
                 tag=f"{tag}.{time_tag}",
                 plot=plot,
+                cm_include_count=cm_include_count,
+                cm_include_percent=cm_include_percent,
             )
 
             return time_tag

--- a/scope/nn.py
+++ b/scope/nn.py
@@ -537,6 +537,7 @@ class DNN(AbstractClassifier):
         names: list = ['train', 'val', 'test'],
         cm_include_count: bool = False,
         cm_include_percent: bool = True,
+        annotate_scores: bool = False,
         **kwargs,
     ):
 
@@ -574,6 +575,7 @@ class DNN(AbstractClassifier):
                         count=cm_include_count,
                         percent=cm_include_percent,
                         categories=['not ' + cname, cname],
+                        annotate_scores=annotate_scores,
                     )
                     stats_dct['accuracy'] = accuracy
                     stats_dct['precision'] = precision

--- a/scope/nn.py
+++ b/scope/nn.py
@@ -506,7 +506,7 @@ class DNN(AbstractClassifier):
         self.meta[f'y_{name}'] = y_eval
 
         # Generate confusion matrix
-        self.meta[f'cm_{name}'] = confusion_matrix(y_eval, y_pred)
+        self.meta[f'cm_{name}'] = confusion_matrix(y_eval, y_pred, normalize='all')
 
         return self.model.evaluate(eval_dataset, **kwargs)
 
@@ -535,6 +535,8 @@ class DNN(AbstractClassifier):
         output_format: str = "h5",
         plot: bool = False,
         names: list = ['train', 'val', 'test'],
+        cm_include_count: bool = False,
+        cm_include_percent: bool = True,
         **kwargs,
     ):
 
@@ -569,7 +571,8 @@ class DNN(AbstractClassifier):
                         self.meta[f'cm_{name}'],
                         figsize=(8, 6),
                         cbar=False,
-                        percent=False,
+                        count=cm_include_count,
+                        percent=cm_include_percent,
                         categories=['not ' + cname, cname],
                     )
                     stats_dct['accuracy'] = accuracy

--- a/scope/utils.py
+++ b/scope/utils.py
@@ -844,9 +844,7 @@ def make_confusion_matrix(
         group_counts = blanks
 
     if percent:
-        group_percentages = [
-            "{0:.2%}".format(value) for value in cf.flatten() / np.sum(cf)
-        ]
+        group_percentages = [np.round(value, 2) for value in cf.flatten() / np.sum(cf)]
     else:
         group_percentages = blanks
 

--- a/scope/utils.py
+++ b/scope/utils.py
@@ -794,6 +794,7 @@ def make_confusion_matrix(
     figsize=None,
     cmap='Blues',
     title=None,
+    annotate_scores=False,
 ):
     '''
     CONFUSION MATRIX CODE ADAPTED FROM https://github.com/DTrimarchi10/confusion_matrix (Dennis Trimarchi)
@@ -854,6 +855,7 @@ def make_confusion_matrix(
     ]
     box_labels = np.asarray(box_labels).reshape(cf.shape[0], cf.shape[1])
 
+    stats_text = ""
     # CODE TO GENERATE SUMMARY STATISTICS & TEXT FOR SUMMARY STATS
     if sum_stats:
         # Accuracy is sum of diagonal divided by total observations
@@ -865,13 +867,12 @@ def make_confusion_matrix(
             precision = cf[1, 1] / sum(cf[:, 1])
             recall = cf[1, 1] / sum(cf[1, :])
             f1_score = 2 * precision * recall / (precision + recall)
-            stats_text = "\n\nAccuracy={:0.3f}\nPrecision={:0.3f}\nRecall={:0.3f}\nF1 Score={:0.3f}".format(
-                accuracy, precision, recall, f1_score
-            )
-        else:
+            if annotate_scores:
+                stats_text = "\n\nAccuracy={:0.3f}\nPrecision={:0.3f}\nRecall={:0.3f}\nF1 Score={:0.3f}".format(
+                    accuracy, precision, recall, f1_score
+                )
+        elif annotate_scores:
             stats_text = "\n\nAccuracy={:0.3f}".format(accuracy)
-    else:
-        stats_text = ""
 
     # SET FIGURE PARAMETERS ACCORDING TO OTHER ARGUMENTS
     if figsize is None:

--- a/scope/xgb.py
+++ b/scope/xgb.py
@@ -424,6 +424,7 @@ class XGB(AbstractClassifier):
         names: list = ['train', 'val', 'test'],
         cm_include_count=False,
         cm_include_percent=True,
+        annotate_scores=False,
         **kwargs,
     ):
         if output_format not in ["json"]:
@@ -483,6 +484,7 @@ class XGB(AbstractClassifier):
                         count=cm_include_count,
                         percent=cm_include_percent,
                         categories=['not ' + cname, cname],
+                        annotate_scores=annotate_scores,
                     )
                     stats_dct['accuracy'] = accuracy
                     stats_dct['precision'] = precision

--- a/scope/xgb.py
+++ b/scope/xgb.py
@@ -388,7 +388,7 @@ class XGB(AbstractClassifier):
         self.meta[f'y_{name}'] = y_eval
 
         # Generate confusion matrix
-        self.meta[f'cm_{name}'] = confusion_matrix(y_eval, y_pred)
+        self.meta[f'cm_{name}'] = confusion_matrix(y_eval, y_pred, normalize='all')
 
         return self.model.eval(d_eval, f'd{name}', **kwargs)
 
@@ -422,6 +422,8 @@ class XGB(AbstractClassifier):
         output_format: str = "json",
         plot: bool = False,
         names: list = ['train', 'val', 'test'],
+        cm_include_count=False,
+        cm_include_percent=True,
         **kwargs,
     ):
         if output_format not in ["json"]:
@@ -463,9 +465,12 @@ class XGB(AbstractClassifier):
                     json.dump(self.meta['importance'], f)
 
                 _ = xgb.plot_importance(
-                    self.model, max_num_features=max_num_features, grid=False
+                    self.model,
+                    max_num_features=max_num_features,
+                    grid=False,
+                    show_values=False,
                 )
-                plt.title(tag + ' Feature Importance')
+                plt.title(tag.split('.')[0])
                 plt.savefig(path / impvars, bbox_inches='tight')
                 plt.close()
 
@@ -475,7 +480,8 @@ class XGB(AbstractClassifier):
                         self.meta[f'cm_{name}'],
                         figsize=(8, 6),
                         cbar=False,
-                        percent=False,
+                        count=cm_include_count,
+                        percent=cm_include_percent,
                         categories=['not ' + cname, cname],
                     )
                     stats_dct['accuracy'] = accuracy


### PR DESCRIPTION
This PR makes updates to the default confusion matrix and feature importance plots:
- Confusion matrices show normalized values by default and do not include score annotations
- Feature importance plots have shortened titles and do not include the F score at the end of each bar

Examples below:
[pnp.20230831_202314_cm.pdf](https://github.com/ZwickyTransientFacility/scope/files/12490067/pnp.20230831_202314_cm.pdf)
[pnp.20230831_202314_impvars.pdf](https://github.com/ZwickyTransientFacility/scope/files/12490068/pnp.20230831_202314_impvars.pdf)
