### PR TITLE
Move Fritz instrument_id request to upload script

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -443,6 +443,7 @@ inputs:
 24. --post_phot_as_comment: flag to post photometry as a comment on the source (bool)
 25. --post_phasefolded_phot: flag to post phase-folded photometry as comment in addition to time series (bool)
 26. --phot_dirname: name of directory in which to save photometry plots (str)
+27. --instrument_name: name of instrument used for observations (str)
 
 process:
 0. include Kowalski host, port, protocol, and token or username+password in config.yaml

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -60,12 +60,6 @@ def api(
     return response
 
 
-# Get up-to-date ZTF instrument id
-name = 'ZTF'
-response_instruments = api('GET', 'api/instrument', max_attempts=MAX_ATTEMPTS)
-instrument_data = response_instruments.json().get('data')
-
-
 def radec_to_iau_name(ra: float, dec: float, prefix: str = "ZTFJ"):
     """Transform R.A./Decl. in degrees to IAU-style hexadecimal designations."""
     if not 0.0 <= ra < 360.0:
@@ -281,6 +275,7 @@ def save_newsource(
     return_id=False,
     return_phot=False,
     skip_phot=False,
+    instrument_id=1,
 ):
 
     # get the lightcurves
@@ -324,11 +319,6 @@ def save_newsource(
     df_photometry = (
         df_photometry.dropna().drop_duplicates('uexpid').reset_index(drop=True)
     )
-
-    for instrument in instrument_data:
-        if instrument['name'] == name:
-            instrument_id = instrument['id']
-            break
 
     photometry = {
         "obj_id": obj_id,

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -259,12 +259,11 @@ def upload_classification(
         classes = [key for key in tax_map.keys()]  # define list of columns to examine
 
     # Get up-to-date ZTF instrument id
-    name = instrument_name
     response_instruments = api('GET', 'api/instrument')
     instrument_data = response_instruments.json().get('data')
 
     for instrument in instrument_data:
-        if instrument['name'] == name:
+        if instrument['name'] == instrument_name:
             instrument_id = instrument['id']
             break
 

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -179,6 +179,7 @@ def upload_classification(
     post_phot_as_comment: bool = False,
     post_phasefolded_phot: bool = False,
     phot_dirname: str = 'phot_plots',
+    instrument_name: str = 'ZTF',
 ):
     """
     Upload labels to Fritz
@@ -208,6 +209,7 @@ def upload_classification(
     :post_phot_as_comment: if True, post photometry as a comment on the source (bool)
     :post_phasefolded_phot: if True, post phase-folded photometry as comment in addition to time series (bool)
     :phot_dirname: Name of directory in which to save photometry plots (str)
+    :instrument_name: Name of instrument used for observations (str)
     """
 
     # read in file to csv
@@ -255,6 +257,16 @@ def upload_classification(
             tax_map = JSON.load(f)
 
         classes = [key for key in tax_map.keys()]  # define list of columns to examine
+
+    # Get up-to-date ZTF instrument id
+    name = instrument_name
+    response_instruments = api('GET', 'api/instrument')
+    instrument_data = response_instruments.json().get('data')
+
+    for instrument in instrument_data:
+        if instrument['name'] == name:
+            instrument_id = instrument['id']
+            break
 
     dict_list = []
     obj_id_dict = {}
@@ -395,6 +407,7 @@ def upload_classification(
                     radius=radius_arcsec,
                     post_source=post_source,
                     skip_phot=skip_phot,
+                    instrument_id=instrument_id,
                 )
             else:
                 obj_id, photometry = save_newsource(
@@ -409,6 +422,7 @@ def upload_classification(
                     radius=radius_arcsec,
                     post_source=post_source,
                     skip_phot=skip_phot,
+                    instrument_id=instrument_id,
                 )
 
         data_groups = []
@@ -855,6 +869,12 @@ if __name__ == "__main__":
         default='phot_plots',
         help="Name of directory in which to save photometry plots",
     )
+    parser.add_argument(
+        "--instrument_name",
+        type=str,
+        default='ZTF',
+        help="Name of instrument used for observations",
+    )
 
     args = parser.parse_args()
 
@@ -887,4 +907,5 @@ if __name__ == "__main__":
         args.post_phot_as_comment,
         args.post_phasefolded_phot,
         args.phot_dirname,
+        args.instrument_name,
     )


### PR DESCRIPTION
This PR moves the instrument API request from `fritz.py` to `scope_upload_classification.py`. This avoids the automatic running of this request whenever code from `fritz.py` is imported, while allowing a new `--instrument_name` argument to be passed to `scope_upload_classification.py`.