### PR TITLE
Fix feature generation KeyError bug

### DIFF
--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -747,6 +747,9 @@ def generate_features(
 
         except ValueError:
             feature_dict.pop(_id)
+            if _id in keep_id_list:
+                keep_id_list.remove(_id)
+                tme_dict.pop(_id)
 
     basicStats = Parallel(n_jobs=Ncore)(
         delayed(lcstats.calc_basic_stats)(id, vals['tme'])


### PR DESCRIPTION
This PR fixes a bug in feature generation in which a KeyError could be raised when calculating basic stats. The bug occurred because sources that generated a separate error during initial/cesium feature generation were not always removed from all relevant dictionaries.