### PR TITLE
Add h5py to doc requirements

### DIFF
--- a/.requirements/doc.txt
+++ b/.requirements/doc.txt
@@ -1,3 +1,4 @@
+h5py>=3.10.0
 astropy>=5.2.2
 fast-histogram>=0.11
 fire>=0.4.0

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -30,7 +30,7 @@ We currently recommend running `scope` with Python 3.11. You may want to begin y
 Once you have a package manager installed, run:
 
 ```bash
-conda create -n scope-env -c conda-forge python=3.11 h5py
+conda create -n scope-env -c conda-forge python=3.11
 conda activate scope-env
 ```
 


### PR DESCRIPTION
This PR adds an h5py requirement to doc.txt, enabling all scope requirements to be installed using pip. This progresses toward the goal of #495.