### PR TITLE
Add configurable time cutoff to mongoDB light curve query

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -20,8 +20,9 @@ kowalski:
     classifications: ZTF_source_classifications_DR16
     # Current alerts (on kowalski)
     alerts: ZTF_alerts
-  # If cutting off queried light curves at a given data release, enter the max MJD (JD - 2400000.5) below
-  max_timestamp_mjd:
+  # If cutting off light curve at a given data release, enter the max HJD below
+  # (JD - 2400000.5 corrected for Earth/Sun light travel time)
+  max_timestamp_hjd:
 fritz:
   token:
   protocol: https

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -21,7 +21,7 @@ kowalski:
     # Current alerts (on kowalski)
     alerts: ZTF_alerts
   # If cutting off light curve at a given data release, enter the max HJD below
-  # (JD - 2400000.5 corrected for Earth/Sun light travel time)
+  # (JD corrected for Earth/Sun light travel time)
   max_timestamp_hjd:
 fritz:
   token:

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -20,6 +20,8 @@ kowalski:
     classifications: ZTF_source_classifications_DR16
     # Current alerts (on kowalski)
     alerts: ZTF_alerts
+  # If cutting off queried light curves at a given data release, enter the max MJD (JD - 2400000.5) below
+  max_timestamp_mjd:
 fritz:
   token:
   protocol: https

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -155,6 +155,8 @@ def get_lightcurves_via_ids(
     get_basic_data=False,
 ):
 
+    cutoff_mjd = config['kowalski']['max_timestamp_mjd']
+
     itr = 0
     lcs = []
     Nsources = len(ids)
@@ -187,6 +189,10 @@ def get_lightcurves_via_ids(
     while True:
         Nqueries = int(np.ceil(Nsources / limit_per_query))
 
+        time_filter = {"$gt": 0.0}
+        if cutoff_mjd is not None:
+            time_filter["$lte"] = 2400000.5 + cutoff_mjd
+
         queries = [
             {
                 "query_type": "find",
@@ -199,6 +205,7 @@ def get_lightcurves_via_ids(
                         "data.programid": {
                             "$in": program_id_selector,
                         },
+                        "data.hjd": time_filter,
                     },
                     "projection": projection,
                 },

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -155,7 +155,7 @@ def get_lightcurves_via_ids(
     get_basic_data=False,
 ):
 
-    cutoff_mjd = config['kowalski']['max_timestamp_mjd']
+    cutoff_hjd = config['kowalski']['max_timestamp_hjd']
 
     itr = 0
     lcs = []
@@ -190,8 +190,8 @@ def get_lightcurves_via_ids(
         Nqueries = int(np.ceil(Nsources / limit_per_query))
 
         time_filter = {"$gt": 0.0}
-        if cutoff_mjd is not None:
-            time_filter["$lte"] = 2400000.5 + cutoff_mjd
+        if cutoff_hjd is not None:
+            time_filter["$lte"] = 2400000.5 + cutoff_hjd
 
         queries = [
             {

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -191,7 +191,7 @@ def get_lightcurves_via_ids(
 
         time_filter = {"$gt": 0.0}
         if cutoff_hjd is not None:
-            time_filter["$lte"] = 2400000.5 + cutoff_hjd
+            time_filter["$lte"] = cutoff_hjd
 
         queries = [
             {


### PR DESCRIPTION
This PR allows all light curves queried from Kowalski to be truncated at a config-specified MJD. Note that since timestamps on Kowalski are measured in HJD, for any given source there is a coordinate-dependent discrepancy of ±8.3 mins between the two time units due to light travel time between the Earth/Sun. This should not be a major issue given that we later enforce a requirement that light curve points be spaced by no less than 30 minutes.