### PR TITLE
Add max_timestamp_hjd as argument in generate_features.py

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -210,6 +210,8 @@ inputs:
 30. --skipCloseSources: flag to skip removal of sources too close to bright stars via Gaia (bool)
 31. --top_n_periods: number of (E)LS, (E)CE periods to pass to (E)AOV if using (E)LS_(E)CE_(E)AOV algorithm (int)
 32. --max_freq: maximum frequency [1 / days] to use for period finding (float). Overridden by --doScaleMinPeriod
+33. --fg_dataset*: path to parquet, hdf5 or csv file containing specific sources for feature generation (str)
+34. --max_timestamp_hjd*: maximum timestamp of queried light curves, HJD (float)
 
 output:
 feature_df : dataframe containing generated features

--- a/scope/fritz.py
+++ b/scope/fritz.py
@@ -91,12 +91,16 @@ def get_lightcurves_via_coords(
     limit_per_query=1000,
     Ncore=1,
     get_basic_data=False,
+    max_timestamp_hjd=None,
 ):
 
     if catalog is None:
         raise ValueError(
             'No catalog specified. Please add one to config.yaml under kowalski: collectons: sources:'
         )
+
+    if max_timestamp_hjd is None:
+        max_timestamp_hjd = config['kowalski']['max_timestamp_hjd']
 
     light_curve_ids = []
     query = {
@@ -142,6 +146,7 @@ def get_lightcurves_via_coords(
         limit_per_query=limit_per_query,
         Ncore=Ncore,
         get_basic_data=get_basic_data,
+        max_timestamp_hjd=max_timestamp_hjd,
     )
 
 
@@ -153,9 +158,11 @@ def get_lightcurves_via_ids(
     limit_per_query=1000,
     Ncore=1,
     get_basic_data=False,
+    max_timestamp_hjd=None,
 ):
 
-    cutoff_hjd = config['kowalski']['max_timestamp_hjd']
+    if max_timestamp_hjd is None:
+        max_timestamp_hjd = config['kowalski']['max_timestamp_hjd']
 
     itr = 0
     lcs = []
@@ -190,8 +197,8 @@ def get_lightcurves_via_ids(
         Nqueries = int(np.ceil(Nsources / limit_per_query))
 
         time_filter = {"$gt": 0.0}
-        if cutoff_hjd is not None:
-            time_filter["$lte"] = cutoff_hjd
+        if max_timestamp_hjd is not None:
+            time_filter["$lte"] = max_timestamp_hjd
 
         queries = [
             {

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -463,6 +463,7 @@ def generate_features(
     top_n_periods: int = 50,
     max_freq: float = 48.0,
     fg_dataset: str = None,
+    max_timestamp_hjd: float = None,
 ):
     """
     Generate features for ZTF light curves
@@ -498,7 +499,9 @@ def generate_features(
     :param doSpecificIDs: flag to perform feature generation for ztf_id column in config-specified file (bool)
     :param skipCloseSources: flag to skip removal of sources too close to bright stars via Gaia (bool)
     :param top_n_periods: number of (E)LS, (E)CE periods to pass to (E)AOV if using (E)LS_(E)CE_(E)AOV algorithm (int)
+    :param max_freq: maximum frequency [1 / days] to use for period finding. Overridden by --doScaleMinPeriod (float)
     :param fg_dataset*: path to parquet, hdf5 or csv file containing specific sources for feature generation (str)
+    :param max_timestamp_hjd*: maximum timestamp of queried light curves, HJD (float)
 
     :return feature_df: dataframe containing generated features
 
@@ -673,6 +676,7 @@ def generate_features(
         limit_per_query=lc_limit,
         Ncore=Ncore,
         get_basic_data=True,
+        max_timestamp_hjd=max_timestamp_hjd,
     )
 
     # Remake feature_gen_source_dict if some light curves are missing
@@ -1362,6 +1366,11 @@ if __name__ == "__main__":
         default=None,
         help="path to parquet, hdf5 or csv file containing specific sources for feature generation",
     )
+    parser.add_argument(
+        "--max_timestamp_hjd",
+        type=float,
+        help="maximum timestamp for queried light curves (HJD)",
+    )
 
     args = parser.parse_args()
 
@@ -1399,4 +1408,5 @@ if __name__ == "__main__":
         top_n_periods=args.top_n_periods,
         max_freq=args.max_freq,
         fg_dataset=args.fg_dataset,
+        max_timestamp_hjd=args.max_timestamp_hjd,
     )


### PR DESCRIPTION
This PR allows `--max_timestamp_hjd` to be specified as an argument in `generate_features.py`, bringing it in line with other arguments that can be specified both in `config.yaml` and the feature generation script.