### PR TITLE
Check for completeness file before loading

### DIFF
--- a/tools/generate_features_slurm.py
+++ b/tools/generate_features_slurm.py
@@ -59,7 +59,7 @@ if path_to_features is not None:
 
 
 def check_quads_for_sources(
-    fields: list = np.arange(0, 2000),
+    fields: list = np.arange(1838, 2000),
     catalog: str = source_catalog,
     count_sources: bool = False,
     minobs: int = 0,
@@ -87,7 +87,7 @@ def check_quads_for_sources(
     missing_ccd_quad = np.zeros(len(fields), dtype=bool)
     field_dct = {}
 
-    if save:
+    if save and (os.path.isfile(BASE_DIR / f'{filename}.json')):
         with open(BASE_DIR / f'{filename}.json', 'r') as f:
             field_dct = json.load(f)
 

--- a/tools/generate_features_slurm.py
+++ b/tools/generate_features_slurm.py
@@ -59,7 +59,7 @@ if path_to_features is not None:
 
 
 def check_quads_for_sources(
-    fields: list = np.arange(1838, 2000),
+    fields: list = np.arange(0, 2000),
     catalog: str = source_catalog,
     count_sources: bool = False,
     minobs: int = 0,


### PR DESCRIPTION
This PR ensures that a completeness file exists before attempting to load it, avoiding a potential error when generating a new file.