### PR TITLE
Exclude invalid files from inference dataset

### DIFF
--- a/tools/inference.py
+++ b/tools/inference.py
@@ -348,7 +348,7 @@ def run_inference(
         )
 
     ts = time.time()
-    DS = ds.dataset(features_filename, format='parquet')
+    DS = ds.dataset(features_filename, format='parquet', exclude_invalid_files=True)
     generator = DS.to_batches(batch_size=batch_size)
     te = time.time()
     if time_run:


### PR DESCRIPTION
This PR excludes invalid files in feature generation output (e.g. `.running` files) from inference, avoiding an `ArrowInvalid` error.