### PR TITLE
Check running jobs before feature generation job submission

### DIFF
--- a/tools/generate_features_job_submission.py
+++ b/tools/generate_features_job_submission.py
@@ -267,6 +267,7 @@ if __name__ == '__main__':
     print('%d jobs remaining to queue...' % nchoice)
 
     if args.doSubmit:
+        failure_count = 0
         counter = running_jobs_count
         status_njobs = njobs
         diff_njobs = 0
@@ -301,6 +302,7 @@ if __name__ == '__main__':
                     print(
                         'Run "squeue -u <username>" to check status of remaining jobs.'
                     )
+                    print(f"{failure_count} jobs failed during full run.")
                     break
             else:
                 # Wait between status checks
@@ -317,24 +319,24 @@ if __name__ == '__main__':
                 print('%d jobs remaining to queue...' % nchoice)
 
                 running_jobs_count = filter_running(args.user)
+
+                n_jobs_diff = counter - running_jobs_count
+                n_jobs_finished = status_njobs - njobs
+                if n_jobs_finished != n_jobs_diff:
+                    failed_this_round = np.abs(n_jobs_finished - n_jobs_diff)
+                    failure_count += failed_this_round
+
                 counter = running_jobs_count
                 # Note that if a job has failed, it will not be re-queued until
                 # its quadrant's .running file is removed (or set --reset_running)
-
-                """
-                # Compute difference in njobs to count available instances
-                diff_njobs = status_njobs - njobs
-                status_njobs = njobs
-
-                # Decrease counter if jobs have finished
-                counter -= diff_njobs
-                """
 
                 # Define size of the next quadrant_indices array
                 size = np.min([new_max_instances - counter, nchoice])
                 # Signal to stop looping when the last set of jobs is queued
                 if size == nchoice:
                     final_round = True
+
+                print(f"Detected {failed_this_round} failed jobs.")
 
     elif args.doSubmitLoop:
         confirm = input(

--- a/tools/generate_features_job_submission.py
+++ b/tools/generate_features_job_submission.py
@@ -269,7 +269,7 @@ if __name__ == '__main__':
     if args.doSubmit:
         failure_count = 0
         counter = running_jobs_count
-        status_njobs = njobs
+        status_njobs = len(df_to_complete)
         diff_njobs = 0
         # Redefine max instances if fewer jobs remain
         new_max_instances = np.min([args.max_instances, nchoice])
@@ -326,6 +326,7 @@ if __name__ == '__main__':
                     failed_this_round = np.abs(n_jobs_finished - n_jobs_diff)
                     failure_count += failed_this_round
 
+                status_njobs = njobs
                 counter = running_jobs_count
                 # Note that if a job has failed, it will not be re-queued until
                 # its quadrant's .running file is removed (or set --reset_running)

--- a/tools/generate_features_job_submission.py
+++ b/tools/generate_features_job_submission.py
@@ -338,7 +338,9 @@ if __name__ == '__main__':
                 if size == nchoice:
                     final_round = True
 
-                print(f"Detected {failed_this_round} failed jobs.")
+                print(
+                    f"Detected {failed_this_round} failed jobs this round ({failure_count} total failures)."
+                )
 
     elif args.doSubmitLoop:
         confirm = input(

--- a/tools/generate_features_job_submission.py
+++ b/tools/generate_features_job_submission.py
@@ -304,7 +304,6 @@ if __name__ == '__main__':
                     break
             else:
                 # Wait between status checks
-                os.system(f"squeue -u {args.user}")
                 print(f"Waiting {args.wait_time_minutes} minutes until next check...")
                 time.sleep(args.wait_time_minutes * 60)
 
@@ -317,12 +316,19 @@ if __name__ == '__main__':
                 print('%d jobs remaining to complete...' % njobs)
                 print('%d jobs remaining to queue...' % nchoice)
 
+                running_jobs_count = filter_running(args.user)
+                counter = running_jobs_count
+                # Note that if a job has failed, it will not be re-queued until
+                # its quadrant's .running file is removed (or set --reset_running)
+
+                """
                 # Compute difference in njobs to count available instances
                 diff_njobs = status_njobs - njobs
                 status_njobs = njobs
 
                 # Decrease counter if jobs have finished
                 counter -= diff_njobs
+                """
 
                 # Define size of the next quadrant_indices array
                 size = np.min([new_max_instances - counter, nchoice])

--- a/tools/generate_features_job_submission.py
+++ b/tools/generate_features_job_submission.py
@@ -210,7 +210,6 @@ if __name__ == '__main__':
         if len(running_jobs) > 1:
             running_jobs = [x.strip().split() for x in running_jobs[1:]]
             for job in running_jobs:
-                # job: ['27628637', 'gpu-share', 'generate', 'bhealy', 'R', '1-01:33:46', '1', 'exp-7-58']
                 job_name = job[2]
                 if "ztf_fg" in job_name:
                     running_jobs_count += 1
@@ -266,7 +265,7 @@ if __name__ == '__main__':
         status_njobs = njobs
         diff_njobs = 0
         # Redefine max instances if fewer jobs remain
-        new_max_instances = np.min([args.max_instances, nchoice])
+        new_max_instances = np.min([args.max_instances - counter, nchoice])
         size = new_max_instances
         final_round = False
         if size == nchoice:

--- a/tools/generate_features_job_submission.py
+++ b/tools/generate_features_job_submission.py
@@ -320,6 +320,7 @@ if __name__ == '__main__':
 
                 running_jobs_count = filter_running(args.user)
 
+                failed_this_round = 0
                 n_jobs_diff = counter - running_jobs_count
                 n_jobs_finished = status_njobs - njobs
                 if n_jobs_finished != n_jobs_diff:

--- a/tools/generate_features_slurm.py
+++ b/tools/generate_features_slurm.py
@@ -315,7 +315,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--job_name",
         type=str,
-        default='generate_features',
+        default='ztf_fg',
         help="job name",
     )
     parser.add_argument(
@@ -641,7 +641,7 @@ if __name__ == "__main__":
     # (Python code can also be run interactively)
     fid = open(os.path.join(slurmDir, 'slurm_submission.sub'), 'w')
     fid.write('#!/bin/bash\n')
-    fid.write(f'#SBATCH --job-name={args.job_name}_submit.job\n')
+    fid.write('#SBATCH --job-name=submit_jobs.job\n')
     fid.write(f'#SBATCH --output=../logs/{args.job_name}_submit_%A_%a.out\n')
     fid.write(f'#SBATCH --error=../logs/{args.job_name}_submit_%A_%a.err\n')
     fid.write(f'#SBATCH -p {args.submit_partition_type}\n')


### PR DESCRIPTION
This PR modifies `tools/generate_features_job_submission.py` to count running jobs using `squeue` before submitting additional feature generation jobs. This allows each 48-hour run of the submission script to be run back-to-back with the next run (e.g. as a cron job), since the new instance of the script will have access to the current active job count.

The new code also makes more efficient use of real time by recognizing any failed jobs and queuing a new jobs to take their place. Previously any failures would restrict the max number of instances available for new jobs queued from the same script run. The user will still need to run another iteration of the script to re-run any failed jobs.