### PR TITLE
Update config defaults with DR20 catalog, DR16 HJD cutoff

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -12,17 +12,18 @@ kowalski:
   timeout: 300
   collections:
     gaia: Gaia_EDR3
-    # Current sources are from DR16 (on melman)
-    sources: ZTF_sources_20230309
-    # Current features generated from DR16 (on melman)
+    # Current sources are from DR20 (on melman)
+    sources: ZTF_sources_20240117
+    # Current features generated from DR16 (on gloria)
     features: ZTF_source_features_DR16
-    # Current classifications are from DR16 (on melman)
+    # Current classifications are from DR16 (on gloria)
     classifications: ZTF_source_classifications_DR16
     # Current alerts (on kowalski)
     alerts: ZTF_alerts
   # If cutting off light curve at a given data release, enter the max HJD below
   # (JD corrected for Earth/Sun light travel time)
-  max_timestamp_hjd:
+  # By default, this is set at the end of DR16 (2459951.5)
+  max_timestamp_hjd: 2459951.5
 fritz:
   token:
   protocol: https


### PR DESCRIPTION
This PR updates the config defaults with the new DR20 catalog on melman (`ZTF_sources_20240117`) and adds the default HJD cutoff (2459951.5) limiting light curves from this catalog to the DR16 timespan.