### PR TITLE
Update config defaults with changes from paper revision

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -870,9 +870,9 @@ features:
       impute_strategy: regress
       periodic: false
     Gaia_EDR3__parallax_error:
-      include: false
+      include: true
       dtype: float
-      impute_strategy: None
+      impute_strategy: median
       periodic: false
     Gaia_EDR3__phot_bp_mean_mag:
       include: true


### PR DESCRIPTION
This PR updates the config defaults to reflect Scope III paper revisions (specifically adding Gaia EDR3 parallax error as an ontological feature with median imputation).