### PR TITLE
Add PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,16 @@
+name: Publish package to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v2.0
+        with:
+          pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This PR adds a workflow to publish scope releases to PyPI using poetry. The workflow runs when a commit is tagged with `v*.*.*`. See https://github.com/marketplace/actions/publish-python-poetry-package for more info.

Note: tests will continue to fail until #514 is merged after some additional testing/debugging.