### PR TITLE
Agn features - DRW, EVT anomaly scores and PDRS 

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -438,6 +438,14 @@ features:
       include: true
       dtype: float
       periodic: false
+    anomaly_flag:
+      include: false
+      dtype: Int64
+      periodic: false
+    anomaly_score:
+      include: false
+      dtype: float
+      periodic: false
     ccd:
       include: false
       dtype: Int64
@@ -447,6 +455,22 @@ features:
       dtype: float
       periodic: false
     dec:
+      include: false
+      dtype: float
+      periodic: false
+    drw_fit_success:
+      include: false
+      dtype: Int64
+      periodic: false
+    drw_max_z:
+      include: false
+      dtype: float
+      periodic: false
+    drw_sigma:
+      include: false
+      dtype: float
+      periodic: false
+    drw_tau:
       include: false
       dtype: float
       periodic: false
@@ -510,6 +534,14 @@ features:
       include: false
       dtype: Int64
       periodic: false
+    flare_duty_cycle:
+      include: false
+      dtype: float
+      periodic: false
+    flare_significance:
+      include: false
+      dtype: float
+      periodic: false
     i60r:
       include: true
       dtype: float
@@ -549,6 +581,10 @@ features:
     n:
       include: false
       dtype: float
+      periodic: false
+    n_flares:
+      include: false
+      dtype: Int64
       periodic: false
     n_ztf_alerts:
       include: false
@@ -624,6 +660,16 @@ features:
       dtype: float
       impute_strategy: None
       periodic: false
+    anomaly_flag:
+      include: false
+      dtype: Int64
+      impute_strategy: None
+      periodic: false
+    anomaly_score:
+      include: false
+      dtype: float
+      impute_strategy: None
+      periodic: false
     ccd:
       include: false
       dtype: Int64
@@ -635,6 +681,26 @@ features:
       impute_strategy: None
       periodic: false
     dec:
+      include: false
+      dtype: float
+      impute_strategy: None
+      periodic: false
+    drw_fit_success:
+      include: false
+      dtype: Int64
+      impute_strategy: None
+      periodic: false
+    drw_max_z:
+      include: false
+      dtype: float
+      impute_strategy: None
+      periodic: false
+    drw_sigma:
+      include: false
+      dtype: float
+      impute_strategy: None
+      periodic: false
+    drw_tau:
       include: false
       dtype: float
       impute_strategy: None
@@ -714,6 +780,16 @@ features:
       dtype: Int64
       impute_strategy: None
       periodic: false
+    flare_duty_cycle:
+      include: false
+      dtype: float
+      impute_strategy: None
+      periodic: false
+    flare_significance:
+      include: false
+      dtype: float
+      impute_strategy: None
+      periodic: false
     i60r:
       include: true
       dtype: float
@@ -762,6 +838,11 @@ features:
     n:
       include: false
       dtype: float
+      impute_strategy: None
+      periodic: false
+    n_flares:
+      include: false
+      dtype: Int64
       impute_strategy: None
       periodic: false
     n_ztf_alerts:
@@ -1489,6 +1570,25 @@ feature_stats:
 feature_generation:
   # Path to save generated features
   path_to_features:
+  # PDRS flare/high-activity segmentation parameters (--doFlareDetection), tuned for ZTF DR23
+  pdrs:
+    bin_size_days: 3.0
+    peak_threshold: 2.0
+    smooth_window: 7
+    min_cluster_size: 3
+    saddle_ratio: 0.2
+    region_threshold: 0.5
+    max_gap_days: 60.0
+  # Damped-random-walk fit parameters (--doDRW). max_iter: 1 is a single plain fit;
+  # max_iter > 1 iteratively masks |z| > z_thr outliers between refits
+  drw:
+    min_epochs: 15
+    max_iter: 1
+    z_thr: 3.0
+  # Extreme-value-theory calibration defaults (tools/evt_calibration.py)
+  evt:
+    pot_percentile: 95.0
+    p_target: 0.01
   # If --doSpecificIDs is set in generate_features.py, the script will generate features for the below dataset instead of a field/ccd/quad.
   # Dataset must contain columns named "ztf_id" and "coordinates" with data in the format of these fields on Kowalski
   # Default dataset is the training set downloadable from Fritz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ notebook = ">=7.0.6"
 cython = ">=3.0.10"
 tables = ">=3.7,<3.9.2"
 pyvo = ">=1.5"
+celerite = ">=0.4.2"
 
 [tool.poetry.extras]
 train = ["tensorflow", "keras-tuner"]
@@ -93,3 +94,4 @@ get-rubin-ids = "tools.get_rubin_ids:main"
 generate-features-rubin = "tools.generate_features_rubin:main"
 run-scope-local = "tools.run_scope_local:main"
 analyze-logs = "tools.analyze_logs:main"
+evt-calibration = "tools.evt_calibration:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ scikit-learn>=0.24.1
 wandb>=0.16.6
 cython>=3.0.10
 pyvo>=1.5
+celerite>=0.4.2

--- a/tests/test_agn_features.py
+++ b/tests/test_agn_features.py
@@ -1,0 +1,329 @@
+"""Tests for the AGN/anomaly feature modules: PDRS flare segmentation,
+DRW (damped random walk) fitting, and EVT calibration.
+
+Uses synthetic lightcurve data — no GPU or Kowalski needed.
+
+Run with:
+    python -m pytest tests/test_agn_features.py -v
+"""
+
+import sys
+import os
+
+# Add the tools directories to the path so we can import the modules directly
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), '..', 'tools', 'featureGeneration')
+)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tools'))
+
+import json  # noqa: E402
+import numpy as np  # noqa: E402
+
+import pdrs  # noqa: E402
+import drw  # noqa: E402
+import evt_calibration as evt  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_flat_lightcurve(
+    n_points=500, t_span=1000.0, mean_mag=17.0, noise_std=0.02, seed=42
+):
+    """Generate a constant-brightness lightcurve with Gaussian noise."""
+    rng = np.random.default_rng(seed)
+    times = np.sort(rng.uniform(0, t_span, n_points))
+    mags = mean_mag + rng.normal(0, noise_std, n_points)
+    magerrs = np.full(n_points, noise_std)
+    return times, mags, magerrs
+
+
+def make_drw_lightcurve(
+    tau=50.0,
+    sigma=0.3,
+    n_points=800,
+    t_span=2000.0,
+    mean_mag=17.0,
+    err=0.02,
+    seed=42,
+):
+    """Generate an exact OU-process lightcurve via the discrete recursion.
+
+    x_{i+1} = x_i exp(-dt/tau) + N(0, sigma^2 (1 - exp(-2 dt/tau)))
+    """
+    rng = np.random.default_rng(seed)
+    times = np.sort(rng.uniform(0, t_span, n_points))
+    x = np.empty(n_points)
+    x[0] = rng.normal(0, sigma)
+    for i in range(1, n_points):
+        decay = np.exp(-(times[i] - times[i - 1]) / tau)
+        x[i] = x[i - 1] * decay + rng.normal(0, sigma * np.sqrt(1 - decay**2))
+    mags = mean_mag + x + rng.normal(0, err, n_points)
+    magerrs = np.full(n_points, err)
+    return times, mags, magerrs
+
+
+def inject_flare(times, mags, t0, amplitude=1.0, rise=2.0, decay=7.0):
+    """Inject a fast-rise exponential-decay flare (a brightening, so the
+    magnitude decreases) into a lightcurve. Returns modified mags."""
+    mags = mags.copy()
+    profile = np.zeros_like(mags)
+    before = times < t0
+    after = ~before
+    profile[before] = amplitude * np.exp((times[before] - t0) / rise)
+    profile[after] = amplitude * np.exp(-(times[after] - t0) / decay)
+    profile[np.abs(times - t0) > 10 * decay] = 0.0
+    return mags - profile
+
+
+# ---------------------------------------------------------------------------
+# TestPDRS
+# ---------------------------------------------------------------------------
+
+
+class TestPDRS:
+    """Tests for PDRS flare/high-activity segmentation."""
+
+    def test_flat_lightcurve_only_weak_detections(self):
+        # Pure noise can produce occasional low-significance regions (peaks
+        # are defined relative to the noise sigma itself); what matters is
+        # that any such detection stays weak and short
+        tme = make_flat_lightcurve()
+        stats = pdrs.calc_pdrs_stats(tme)
+        assert stats['flare_significance'] < 4.0
+        assert stats['flare_duty_cycle'] < 0.1
+
+    def test_injected_flare_detected(self):
+        times, mags, magerrs = make_flat_lightcurve(seed=1)
+        flat_stats = pdrs.calc_pdrs_stats((times, mags, magerrs))
+
+        mags = inject_flare(times, mags, t0=500.0, amplitude=1.5, decay=5.0)
+        stats = pdrs.calc_pdrs_stats((times, mags, magerrs))
+
+        assert stats['n_flares'] >= 1
+        assert stats['flare_significance'] > 10.0
+        assert stats['flare_significance'] > 3.0 * max(
+            flat_stats['flare_significance'], 1.0
+        )
+        assert 0.0 < stats['flare_duty_cycle'] < 0.1
+
+    def test_two_flares_detected_separately(self):
+        # Constructed binned series: two identical bumps on a gently noisy
+        # baseline, separated by a deep saddle, must remain two regions
+        rng = np.random.default_rng(0)
+        mjd = np.arange(40) * 3.0
+        flux = 1.0 + rng.normal(0, 0.01, 40)
+        bump = np.array([0.1, 0.3, 0.6, 0.3, 0.1])
+        flux[8:13] += bump
+        flux[28:33] += bump
+
+        flares = pdrs.detect_flares(mjd, flux)
+        assert len(flares) == 2
+        assert flares[0]['start'] <= mjd[10] <= flares[0]['end']
+        assert flares[1]['start'] <= mjd[30] <= flares[1]['end']
+
+    def test_detected_region_overlaps_injection(self):
+        times, mags, magerrs = make_flat_lightcurve(seed=3)
+        t0 = 600.0
+        mags = inject_flare(times, mags, t0=t0, amplitude=1.0, decay=10.0)
+
+        flux = 10 ** (-0.4 * (mags - np.median(mags)))
+        fluxerr = 0.4 * np.log(10) * flux * magerrs
+        b_t, b_f, _ = pdrs.bin_light_curve(times, flux, fluxerr)
+        flares = pdrs.detect_flares(b_t, b_f)
+
+        assert len(flares) >= 1
+        assert any(f['start'] - 10 <= t0 <= f['end'] + 10 for f in flares)
+
+    def test_too_few_points_gives_nan(self):
+        times = np.array([1.0, 2.0, 3.0])
+        mags = np.array([17.0, 17.1, 17.0])
+        magerrs = np.array([0.02, 0.02, 0.02])
+        stats = pdrs.calc_pdrs_stats((times, mags, magerrs))
+        assert all(np.isnan(v) for v in stats.values())
+
+    def test_stat_keys_complete(self):
+        tme = make_flat_lightcurve(n_points=100)
+        stats = pdrs.calc_pdrs_stats(tme)
+        assert set(stats.keys()) == set(pdrs.PDRS_FEATURE_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# TestDRW
+# ---------------------------------------------------------------------------
+
+
+class TestDRW:
+    """Tests for DRW fitting and residual-based anomaly statistics."""
+
+    def test_recovers_known_parameters(self):
+        tme = make_drw_lightcurve(tau=50.0, sigma=0.3, n_points=1000, seed=10)
+        stats = drw.calc_drw_stats(tme)
+        assert stats['drw_fit_success'] == 1
+        # tau recovery is noisy even for well-sampled curves; require the
+        # right order of magnitude
+        assert 15.0 < stats['drw_tau'] < 200.0
+        assert 0.15 < stats['drw_sigma'] < 0.6
+
+    def test_quiet_drw_has_moderate_max_z(self):
+        tme = make_drw_lightcurve(tau=50.0, sigma=0.3, seed=11)
+        stats = drw.calc_drw_stats(tme)
+        assert stats['drw_fit_success'] == 1
+        assert np.isfinite(stats['drw_max_z'])
+        assert stats['drw_max_z'] < 6.0
+
+    def test_flare_raises_max_z(self):
+        times, mags, magerrs = make_drw_lightcurve(tau=50.0, sigma=0.3, seed=12)
+        quiet = drw.calc_drw_stats((times, mags, magerrs))
+
+        flare_mags = inject_flare(times, mags, t0=1000.0, amplitude=1.5, decay=7.0)
+        flared = drw.calc_drw_stats((times, flare_mags, magerrs))
+
+        assert flared['drw_max_z'] > 2.0 * quiet['drw_max_z']
+        assert flared['drw_max_z'] > 8.0
+
+    def test_ou_resid_standardization(self):
+        # With the true parameters, one-step-ahead residuals of a pure OU
+        # process should be ~N(0, 1)
+        tau, sigma, mean_mag, err = 50.0, 0.3, 17.0, 0.02
+        times, mags, magerrs = make_drw_lightcurve(
+            tau=tau, sigma=sigma, mean_mag=mean_mag, err=err, n_points=1000, seed=13
+        )
+        z = drw.ou_resid(times, mags, magerrs, tau, sigma, mean_mag)
+        assert abs(np.std(z) - 1.0) < 0.2
+        assert np.max(np.abs(z)) < 6.0
+
+    def test_too_few_points_gives_nan(self):
+        times, mags, magerrs = make_flat_lightcurve(n_points=10)
+        stats = drw.calc_drw_stats((times, mags, magerrs))
+        assert stats['drw_fit_success'] == 0
+        assert np.isnan(stats['drw_tau'])
+        assert np.isnan(stats['drw_max_z'])
+
+    def test_constant_lightcurve_does_not_crash(self):
+        times = np.linspace(0, 100, 50)
+        mags = np.full(50, 17.0)
+        magerrs = np.full(50, 0.02)
+        stats = drw.calc_drw_stats((times, mags, magerrs))
+        assert set(stats.keys()) == set(drw.DRW_FEATURE_KEYS)
+
+    def test_iterative_masking_option(self):
+        times, mags, magerrs = make_drw_lightcurve(tau=50.0, sigma=0.3, seed=14)
+        mags = inject_flare(times, mags, t0=1000.0, amplitude=1.5, decay=7.0)
+        stats = drw.calc_drw_stats((times, mags, magerrs), max_iter=3)
+        assert stats['drw_fit_success'] == 1
+        assert np.isfinite(stats['drw_max_z'])
+
+    def test_batch_matches_single(self):
+        tme1 = make_drw_lightcurve(seed=15)
+        tme2 = make_flat_lightcurve(seed=16)
+        batch = drw.calc_drw_stats_batch([tme1, tme2], Ncore=1)
+        single = [drw.calc_drw_stats(tme1), drw.calc_drw_stats(tme2)]
+        for b, s in zip(batch, single):
+            for key in drw.DRW_FEATURE_KEYS:
+                if np.isnan(s[key]):
+                    assert np.isnan(b[key])
+                else:
+                    assert b[key] == s[key]
+
+
+# ---------------------------------------------------------------------------
+# TestEVT
+# ---------------------------------------------------------------------------
+
+
+class TestEVT:
+    """Tests for the EVT (peaks-over-threshold / GPD) calibration."""
+
+    @staticmethod
+    def make_max_z_population(n=3000, seed=20):
+        rng = np.random.default_rng(seed)
+        # Heavy-ish tailed positive population resembling max |z| values
+        return 2.0 + np.abs(rng.standard_normal(n)) + rng.exponential(0.5, n)
+
+    def test_fit_gpd_basic(self):
+        vals = self.make_max_z_population()
+        calib = evt.fit_gpd(vals, pot_percentile=95.0)
+        assert np.isfinite(calib['shape'])
+        assert calib['scale'] > 0
+        assert calib['nu'] == np.sum(vals > calib['u'])
+        assert abs(calib['u'] - np.percentile(vals, 95.0)) < 1e-8
+
+    def test_detection_threshold_above_u_and_monotonic(self):
+        vals = self.make_max_z_population()
+        calib = evt.fit_gpd(vals)
+        thr_1pct = evt.detection_threshold(calib, p_target=0.01)
+        thr_01pct = evt.detection_threshold(calib, p_target=0.001)
+        assert thr_1pct > calib['u']
+        assert thr_01pct > thr_1pct
+
+    def test_exceedance_prob_decreasing(self):
+        vals = self.make_max_z_population()
+        calib = evt.fit_gpd(vals)
+        z = np.array([2.0, 3.0, calib['u'] + 0.5, calib['u'] + 2.0])
+        p = evt.exceedance_prob(z, calib)
+        assert np.all(np.diff(p) < 0)
+        assert np.all((p > 0) & (p <= 1))
+
+    def test_anomaly_score_orders_sources(self):
+        vals = self.make_max_z_population()
+        calib = evt.fit_gpd(vals)
+        thr = evt.detection_threshold(calib, p_target=0.01)
+        scores = evt.anomaly_score(np.array([np.median(vals), thr + 1.0]), calib)
+        assert scores[1] > scores[0]
+
+    def test_anomaly_score_nan_passthrough(self):
+        vals = self.make_max_z_population()
+        calib = evt.fit_gpd(vals)
+        scores = evt.anomaly_score(np.array([3.0, np.nan]), calib)
+        assert np.isfinite(scores[0])
+        assert np.isnan(scores[1])
+
+    def test_calibration_json_serializable(self):
+        vals = self.make_max_z_population()
+        calib = evt.fit_gpd(vals)
+        calib['detection_threshold'] = float(evt.detection_threshold(calib, 0.01))
+        restored = json.loads(json.dumps(calib))
+        assert restored['u'] == calib['u']
+
+    def test_fit_gpd_rejects_small_samples(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            evt.fit_gpd(np.ones(10))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: DRW max_z of a flaring source stands out after calibration
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_flaring_source_flagged_against_quiet_population(self):
+        max_z_population = []
+        for seed in range(40):
+            tme = make_drw_lightcurve(
+                tau=50.0, sigma=0.3, n_points=300, t_span=1500.0, seed=100 + seed
+            )
+            stats = drw.calc_drw_stats(tme)
+            if np.isfinite(stats['drw_max_z']):
+                max_z_population.append(stats['drw_max_z'])
+
+        # Pad the population for a stable GPD fit using resampling with noise
+        rng = np.random.default_rng(0)
+        base = np.array(max_z_population)
+        pop = np.concatenate(
+            [base, rng.choice(base, 500) + rng.normal(0, 0.1, 500)]
+        )
+
+        calib = evt.fit_gpd(pop, pot_percentile=90.0)
+        thr = evt.detection_threshold(calib, p_target=0.01)
+
+        times, mags, magerrs = make_drw_lightcurve(
+            tau=50.0, sigma=0.3, n_points=300, t_span=1500.0, seed=999
+        )
+        mags = inject_flare(times, mags, t0=700.0, amplitude=2.0, decay=7.0)
+        flared = drw.calc_drw_stats((times, mags, magerrs))
+
+        assert flared['drw_max_z'] > thr

--- a/tests/test_agn_features.py
+++ b/tests/test_agn_features.py
@@ -313,9 +313,7 @@ class TestEndToEnd:
         # Pad the population for a stable GPD fit using resampling with noise
         rng = np.random.default_rng(0)
         base = np.array(max_z_population)
-        pop = np.concatenate(
-            [base, rng.choice(base, 500) + rng.normal(0, 0.1, 500)]
-        )
+        pop = np.concatenate([base, rng.choice(base, 500) + rng.normal(0, 0.1, 500)])
 
         calib = evt.fit_gpd(pop, pot_percentile=90.0)
         thr = evt.detection_threshold(calib, p_target=0.01)

--- a/tools/evt_calibration.py
+++ b/tools/evt_calibration.py
@@ -226,8 +226,7 @@ def main():
     per_filter = (not args.no_per_filter) and ('filter' in pooled.columns)
     if per_filter:
         groups = {
-            int(flt): grp['drw_max_z'].values
-            for flt, grp in pooled.groupby('filter')
+            int(flt): grp['drw_max_z'].values for flt, grp in pooled.groupby('filter')
         }
     else:
         groups = {'all': pooled['drw_max_z'].values}
@@ -293,9 +292,9 @@ def main():
             score[sel] = anomaly_score(z, calib)
             finite = np.isfinite(z)
             group_flag = np.full(z.shape, np.nan)
-            group_flag[finite] = (
-                z[finite] > calib['detection_threshold']
-            ).astype(float)
+            group_flag[finite] = (z[finite] > calib['detection_threshold']).astype(
+                float
+            )
             flag[sel] = group_flag
 
         df['anomaly_score'] = score

--- a/tools/evt_calibration.py
+++ b/tools/evt_calibration.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python
+"""
+EVT calibration of DRW anomaly scores.
+
+Population-level step of the AGN/anomaly feature set: pools the drw_max_z
+values produced by generate_features.py (--doDRW) across feature files, fits
+a generalized Pareto distribution (GPD) to the tail via peaks-over-threshold
+(POT), and converts each source's drw_max_z into
+
+    anomaly_score  -log10 of the exceedance probability P(max_z > z)
+    anomaly_flag   1 if drw_max_z exceeds the detection threshold derived
+                   from the target false-alarm rate, else 0
+
+Calibration is performed per filter (per ZTF band) by default and saved to a
+JSON file so that later runs can score new sources against the same frozen
+threshold. By default the tool only reports; pass --apply to write the
+anomaly_score/anomaly_flag columns back into the feature files.
+
+Usage:
+    python tools/evt_calibration.py --features-dir generated_features
+    python tools/evt_calibration.py --features-dir generated_features --apply
+"""
+
+import argparse
+import json
+import pathlib
+
+import numpy as np
+import pandas as pd
+from scipy.stats import genpareto
+
+DEFAULT_POT_PERCENTILE = 95.0
+DEFAULT_P_TARGET = 0.01
+
+N_QUANTILE_GRID = 201
+
+
+def _load_evt_config_defaults():
+    """Read feature_generation.evt from the SCoPe config, if available."""
+    try:
+        from scope.utils import parse_load_config
+
+        config = parse_load_config()
+        return config.get('feature_generation', {}).get('evt', {}) or {}
+    except Exception:
+        return {}
+
+
+def fit_gpd(max_z, pot_percentile=DEFAULT_POT_PERCENTILE):
+    """Fit a GPD to the POT exceedances of a pooled max_z sample.
+
+    Returns a calibration dict with the GPD parameters, threshold u, sample
+    counts, and an empirical quantile grid used to score sub-threshold values.
+    """
+    vals = np.asarray(max_z, dtype=float)
+    vals = vals[np.isfinite(vals)]
+    n = len(vals)
+    if n < 20:
+        raise ValueError(f"Need at least 20 finite max_z values, got {n}")
+
+    u = float(np.percentile(vals, pot_percentile))
+    excesses = vals[vals > u] - u
+    nu = len(excesses)
+    if nu < 5:
+        raise ValueError(f"Only {nu} exceedances above threshold {u:.3f}")
+
+    # Location fixed at zero: excesses start at zero by definition
+    shape, _, scale = genpareto.fit(excesses, floc=0)
+
+    levels = np.linspace(0.0, 1.0, N_QUANTILE_GRID)
+    quantiles = np.quantile(vals, levels)
+
+    return {
+        'pot_percentile': float(pot_percentile),
+        'u': u,
+        'shape': float(shape),
+        'scale': float(scale),
+        'n': int(n),
+        'nu': int(nu),
+        'quantile_levels': levels.tolist(),
+        'quantile_values': np.asarray(quantiles, dtype=float).tolist(),
+    }
+
+
+def detection_threshold(calib, p_target=DEFAULT_P_TARGET):
+    """Invert the GPD exceedance probability for a target false-alarm rate."""
+    u, shape, scale = calib['u'], calib['shape'], calib['scale']
+    n, nu = calib['n'], calib['nu']
+    if nu == 0:
+        return np.inf
+    ratio = (n * p_target) / nu
+    if abs(shape) < 1e-12:
+        return u + scale * np.log(1.0 / ratio)
+    return u + (scale / shape) * (ratio ** (-shape) - 1.0)
+
+
+def exceedance_prob(z, calib):
+    """P(max_z > z): GPD tail above u, empirical quantile grid below."""
+    z = np.atleast_1d(np.asarray(z, dtype=float))
+    p = np.full(z.shape, np.nan)
+
+    u, shape, scale = calib['u'], calib['shape'], calib['scale']
+    frac_u = calib['nu'] / calib['n']
+    levels = np.asarray(calib['quantile_levels'])
+    quantiles = np.asarray(calib['quantile_values'])
+
+    finite = np.isfinite(z)
+
+    below = finite & (z <= u)
+    cdf = np.interp(z[below], quantiles, levels)
+    p[below] = 1.0 - cdf
+
+    above = finite & (z > u)
+    zz = z[above] - u
+    if abs(shape) < 1e-12:
+        tail = np.exp(-zz / scale)
+    else:
+        arg = 1.0 + shape * zz / scale
+        tail = np.where(arg > 0, arg ** (-1.0 / shape), 0.0)
+    p[above] = frac_u * tail
+
+    return np.clip(p, 1e-300, 1.0)
+
+
+def anomaly_score(z, calib):
+    """-log10 exceedance probability; higher = more anomalous. NaN-safe."""
+    z = np.atleast_1d(np.asarray(z, dtype=float))
+    score = np.full(z.shape, np.nan)
+    finite = np.isfinite(z)
+    score[finite] = -np.log10(exceedance_prob(z[finite], calib))
+    return score
+
+
+def collect_feature_files(features_dir, pattern):
+    paths = sorted(pathlib.Path(features_dir).rglob(pattern))
+    usable = []
+    for path in paths:
+        try:
+            columns = pd.read_parquet(path, columns=['drw_max_z']).columns
+        except Exception:
+            continue
+        if 'drw_max_z' in columns:
+            usable.append(path)
+    return usable
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--features-dir",
+        type=str,
+        required=True,
+        help="directory containing generated feature files",
+    )
+    parser.add_argument(
+        "--file-pattern",
+        type=str,
+        default="*.parquet",
+        help="glob pattern for feature files (searched recursively)",
+    )
+    parser.add_argument(
+        "--pot-percentile",
+        type=float,
+        default=None,
+        help="peaks-over-threshold percentile of the pooled max_z distribution "
+        "(default: feature_generation.evt in config, else 95)",
+    )
+    parser.add_argument(
+        "--p-target",
+        type=float,
+        default=None,
+        help="target false-alarm rate for the detection threshold "
+        "(default: feature_generation.evt in config, else 0.01)",
+    )
+    parser.add_argument(
+        "--config-path",
+        type=str,
+        help="path to config file providing feature_generation.evt defaults",
+    )
+    parser.add_argument(
+        "--no-per-filter",
+        action="store_true",
+        default=False,
+        help="pool all filters into a single calibration",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="path for the calibration JSON (default: <features-dir>/evt_calibration.json)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="write anomaly_score/anomaly_flag columns back into the feature files",
+    )
+    args = parser.parse_args()
+
+    config_defaults = _load_evt_config_defaults()
+    pot_percentile = (
+        args.pot_percentile
+        if args.pot_percentile is not None
+        else config_defaults.get('pot_percentile', DEFAULT_POT_PERCENTILE)
+    )
+    p_target = (
+        args.p_target
+        if args.p_target is not None
+        else config_defaults.get('p_target', DEFAULT_P_TARGET)
+    )
+
+    features_dir = pathlib.Path(args.features_dir)
+    paths = collect_feature_files(features_dir, args.file_pattern)
+    if not paths:
+        print(
+            f"No feature files with a drw_max_z column found under {features_dir} "
+            f"(pattern {args.file_pattern}). Run generate-features with --doDRW first."
+        )
+        return
+
+    print(f"Found {len(paths)} feature file(s) with drw_max_z.")
+
+    frames = [pd.read_parquet(path) for path in paths]
+    pooled = pd.concat(frames, ignore_index=True)
+
+    per_filter = (not args.no_per_filter) and ('filter' in pooled.columns)
+    if per_filter:
+        groups = {
+            int(flt): grp['drw_max_z'].values
+            for flt, grp in pooled.groupby('filter')
+        }
+    else:
+        groups = {'all': pooled['drw_max_z'].values}
+
+    calibration = {
+        'p_target': p_target,
+        'per_filter': per_filter,
+        'groups': {},
+    }
+
+    for key, values in groups.items():
+        try:
+            calib = fit_gpd(values, pot_percentile=pot_percentile)
+        except ValueError as e:
+            print(f"Group {key}: calibration failed ({e}); skipping.")
+            continue
+        threshold = float(detection_threshold(calib, p_target))
+        calib['detection_threshold'] = threshold
+        calibration['groups'][str(key)] = calib
+
+        n_flagged = int(np.nansum(values > threshold))
+        print(
+            f"Group {key}: n={calib['n']} u={calib['u']:.3f} "
+            f"shape={calib['shape']:.3f} scale={calib['scale']:.3f} "
+            f"threshold={threshold:.3f} flagged={n_flagged} "
+            f"({100.0 * n_flagged / max(calib['n'], 1):.2f}%)"
+        )
+
+    if not calibration['groups']:
+        print("No group could be calibrated; nothing written.")
+        return
+
+    output = (
+        pathlib.Path(args.output)
+        if args.output is not None
+        else features_dir / 'evt_calibration.json'
+    )
+    with open(output, 'w') as f:
+        json.dump(calibration, f, indent=2)
+    print(f"Calibration saved to {output}")
+
+    if not args.apply:
+        print("Dry run: pass --apply to write anomaly_score/anomaly_flag columns.")
+        return
+
+    for path, df in zip(paths, frames):
+        score = np.full(len(df), np.nan)
+        flag = np.full(len(df), np.nan)
+
+        if per_filter:
+            keys = df['filter'].astype('Int64')
+        else:
+            keys = pd.Series(['all'] * len(df))
+
+        for key, calib in calibration['groups'].items():
+            if per_filter:
+                sel = (keys.astype(str) == key).values
+            else:
+                sel = np.ones(len(df), dtype=bool)
+            if not sel.any():
+                continue
+            z = df.loc[sel, 'drw_max_z'].values
+            score[sel] = anomaly_score(z, calib)
+            finite = np.isfinite(z)
+            group_flag = np.full(z.shape, np.nan)
+            group_flag[finite] = (
+                z[finite] > calib['detection_threshold']
+            ).astype(float)
+            flag[sel] = group_flag
+
+        df['anomaly_score'] = score
+        df['anomaly_flag'] = flag
+        df.to_parquet(path, index=False)
+        print(f"Updated {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/featureGeneration/drw.py
+++ b/tools/featureGeneration/drw.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Damped-random-walk (DRW / Ornstein-Uhlenbeck) features for AGN-like
+stochastic variability.
+
+Fits a celerite Gaussian process with a RealTerm (the DRW kernel) plus a
+JitterTerm (extra white noise absorbing underestimated photometric errors)
+by maximizing the marginal likelihood with L-BFGS-B. Standardized one-step-
+ahead residuals under the fitted OU model provide an anomaly statistic:
+
+    drw_tau          damping timescale (days)
+    drw_sigma        asymptotic rms variability amplitude (mag)
+    drw_max_z        max |standardized one-step-ahead residual|
+    drw_fit_success  1 if the optimizer converged, else 0
+
+An optional iterative sigma-clipping scheme (max_iter > 1) refits after
+masking points with |z| > z_thr so that flares do not contaminate their own
+baseline. The default is a single plain fit (max_iter = 1). Configurable via
+config.yaml under feature_generation.drw.
+
+Note: sigma here is the asymptotic (process) rms; the structure-function
+amplitude commonly reported in the AGN literature is SF_inf = sqrt(2) * sigma.
+"""
+
+import numpy as np
+from scipy.optimize import minimize
+
+import celerite
+from celerite import terms
+
+DEFAULT_MIN_EPOCHS = 15
+DEFAULT_MAX_ITER = 1
+DEFAULT_Z_THR = 3.0
+
+# Bounds on the (natural) log-parameters of the kernel
+LOG_A_BOUNDS = (np.log(1e-8), np.log(1e2))  # process variance (mag^2)
+LOG_C_BOUNDS = (np.log(1e-5), np.log(1e2))  # inverse timescale (1/day)
+LOG_JITTER_BOUNDS = (np.log(1e-6), np.log(1e1))  # extra white noise (mag)
+
+DRW_FEATURE_KEYS = ['drw_tau', 'drw_sigma', 'drw_max_z', 'drw_fit_success']
+
+
+def _nan_stats():
+    stats = {key: np.nan for key in DRW_FEATURE_KEYS}
+    stats['drw_fit_success'] = 0
+    return stats
+
+
+def _neg_log_like(params, y, gp):
+    gp.set_parameter_vector(params)
+    try:
+        return -gp.log_likelihood(y)
+    except celerite.solver.LinAlgError:
+        return 1e25
+
+
+def fit_drw(t, y, yerr):
+    """Fit a DRW (RealTerm) + jitter GP to a single light curve.
+
+    :param t: times (days), sorted ascending
+    :param y: magnitudes
+    :param yerr: magnitude errors
+
+    :return: (tau, sigma, mu, jitter, success)
+        tau: damping timescale (days)
+        sigma: asymptotic rms amplitude (mag)
+        mu: fitted mean magnitude
+        jitter: fitted excess white-noise amplitude (mag)
+        success: bool, optimizer convergence
+    """
+    var = np.var(y)
+    baseline = t[-1] - t[0]
+
+    log_a_init = np.log(max(var, 1e-8))
+    log_c_init = np.log(5.0 / max(baseline, 1.0))
+    log_jitter_init = np.log(max(np.median(yerr), 1e-4))
+
+    kernel = terms.RealTerm(
+        log_a=np.clip(log_a_init, *LOG_A_BOUNDS),
+        log_c=np.clip(log_c_init, *LOG_C_BOUNDS),
+        bounds=dict(log_a=LOG_A_BOUNDS, log_c=LOG_C_BOUNDS),
+    ) + terms.JitterTerm(
+        log_sigma=np.clip(log_jitter_init, *LOG_JITTER_BOUNDS),
+        bounds=dict(log_sigma=LOG_JITTER_BOUNDS),
+    )
+
+    gp = celerite.GP(kernel, mean=np.median(y), fit_mean=True)
+    gp.compute(t, yerr)
+
+    # Numerical gradients: celerite's analytic gradient requires autograd
+    r = minimize(
+        _neg_log_like,
+        gp.get_parameter_vector(),
+        method='L-BFGS-B',
+        bounds=gp.get_parameter_bounds(),
+        args=(y, gp),
+    )
+    gp.set_parameter_vector(r.x)
+
+    params = gp.get_parameter_dict()
+    tau = 1.0 / np.exp(params['kernel:terms[0]:log_c'])
+    sigma = np.sqrt(np.exp(params['kernel:terms[0]:log_a']))
+    jitter = np.exp(params['kernel:terms[1]:log_sigma'])
+    mu = params['mean:value']
+
+    return tau, sigma, mu, jitter, bool(r.success)
+
+
+def ou_resid(t, y, yerr, tau, sigma, mu, jitter=0.0):
+    """Standardized one-step-ahead residuals under an OU model.
+
+    The prediction for epoch i conditions on the previous observed epoch:
+        m_i = mu + (y_{i-1} - mu) * exp(-dt/tau)
+        v_i = sigma^2 * (1 - exp(-2 dt/tau))
+        z_i = (y_i - m_i) / sqrt(v_i + yerr_i^2 + jitter^2)
+    The first epoch is standardized against the stationary distribution.
+    """
+    t = np.asarray(t, dtype=float)
+    y = np.asarray(y, dtype=float)
+    yerr = np.asarray(yerr, dtype=float)
+
+    dt = np.diff(t)
+    decay = np.exp(-dt / tau)
+
+    m = np.empty_like(y)
+    v = np.empty_like(y)
+    m[0] = mu
+    v[0] = sigma**2
+    m[1:] = mu + (y[:-1] - mu) * decay
+    v[1:] = sigma**2 * (1.0 - decay**2)
+
+    return (y - m) / np.sqrt(v + yerr**2 + jitter**2)
+
+
+def calc_drw_stats(
+    tme,
+    min_epochs=DEFAULT_MIN_EPOCHS,
+    max_iter=DEFAULT_MAX_ITER,
+    z_thr=DEFAULT_Z_THR,
+):
+    """Compute DRW features for a single (times, mags, magerrs) tuple.
+
+    With max_iter = 1 (default) a single plain fit is performed. With
+    max_iter > 1, points with |z| > z_thr are masked and the model refit,
+    keeping flares out of their own baseline; residuals are always evaluated
+    on all points.
+
+    Returns a dict with keys drw_tau, drw_sigma, drw_max_z, drw_fit_success.
+    Values are NaN (and drw_fit_success = 0) when the light curve is too
+    short or the fit fails.
+    """
+    t = np.asarray(tme[0], dtype=float)
+    y = np.asarray(tme[1], dtype=float)
+    yerr = np.asarray(tme[2], dtype=float)
+
+    keep = np.isfinite(t) & np.isfinite(y) & np.isfinite(yerr) & (yerr > 0)
+    t, y, yerr = t[keep], y[keep], yerr[keep]
+
+    if len(t) < min_epochs:
+        return _nan_stats()
+
+    order = np.argsort(t)
+    t, y, yerr = t[order], y[order], yerr[order]
+
+    # Merge exactly simultaneous epochs' handling: celerite requires strictly
+    # increasing times
+    unique = np.concatenate(([True], np.diff(t) > 0))
+    t, y, yerr = t[unique], y[unique], yerr[unique]
+    if len(t) < min_epochs:
+        return _nan_stats()
+
+    mask = np.zeros(len(t), dtype=bool)
+    result = None
+
+    for _ in range(max(1, int(max_iter))):
+        ix = ~mask
+        if ix.sum() < min_epochs:
+            break
+
+        try:
+            tau, sigma, mu, jitter, success = fit_drw(t[ix], y[ix], yerr[ix])
+        except Exception:
+            break
+
+        z = ou_resid(t, y, yerr, tau, sigma, mu, jitter)
+        result = {
+            'drw_tau': float(tau),
+            'drw_sigma': float(sigma),
+            'drw_max_z': float(np.max(np.abs(z))),
+            'drw_fit_success': int(success),
+        }
+
+        new_mask = np.abs(z) > z_thr
+        new_mask[0] = new_mask[-1] = False
+        if np.array_equal(new_mask, mask):
+            break
+        mask = new_mask
+
+    if result is None:
+        return _nan_stats()
+
+    return result
+
+
+def calc_drw_stats_batch(
+    tme_list,
+    Ncore=1,
+    min_epochs=DEFAULT_MIN_EPOCHS,
+    max_iter=DEFAULT_MAX_ITER,
+    z_thr=DEFAULT_Z_THR,
+):
+    """Compute DRW features for a list of (times, mags, magerrs) tuples,
+    optionally in parallel across Ncore processes.
+    """
+    from functools import partial
+
+    func = partial(
+        calc_drw_stats, min_epochs=min_epochs, max_iter=max_iter, z_thr=z_thr
+    )
+
+    if Ncore is None or Ncore <= 1 or len(tme_list) < 2:
+        return [func(tme) for tme in tme_list]
+
+    import multiprocessing as mp
+
+    with mp.Pool(min(Ncore, len(tme_list))) as pool:
+        return pool.map(func, tme_list)

--- a/tools/featureGeneration/pdrs.py
+++ b/tools/featureGeneration/pdrs.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+PDRS: peak-detection region segmentation for flare / high-activity features.
+
+Detects flare regions in a light curve by finding significant peaks in binned
+flux, growing each peak into a region using a gradient-guided expansion,
+merging regions across shallow saddles, and gating regions on their median
+flux. Summarizes the detected regions as scalar features suitable for the
+SCoPe feature pipeline:
+
+    n_flares            number of distinct flare regions
+    flare_significance  max over regions of (peak flux - median) / std
+    flare_duty_cycle    fraction of the light curve baseline inside regions
+
+Default hyperparameters are tuned for ZTF DR23 and are configurable via
+config.yaml under feature_generation.pdrs.
+"""
+
+import numpy as np
+
+DEFAULT_BIN_SIZE_DAYS = 3.0
+DEFAULT_PEAK_THRESHOLD = 2.0
+DEFAULT_SMOOTH_WINDOW = 7
+DEFAULT_MIN_CLUSTER_SIZE = 3
+DEFAULT_SADDLE_RATIO = 0.2
+DEFAULT_REGION_THRESHOLD = 0.5
+DEFAULT_MAX_GAP_DAYS = 60.0
+
+PDRS_FEATURE_KEYS = ['n_flares', 'flare_significance', 'flare_duty_cycle']
+
+
+def _nan_stats():
+    return {key: np.nan for key in PDRS_FEATURE_KEYS}
+
+
+def get_uneven_gradient(mjd, flux, window):
+    """
+    O(N) gradient estimation for unevenly spaced data.
+    Provides a smoothed 'trend' used for the expansion/descent logic.
+    """
+    n = len(flux)
+    grad = np.zeros(n)
+    half_w = window // 2
+    mjd_ref = mjd - mjd[0]
+
+    cs_x = np.cumsum(np.concatenate(([0], mjd_ref)))
+    cs_y = np.cumsum(np.concatenate(([0], flux)))
+    cs_xx = np.cumsum(np.concatenate(([0], mjd_ref**2)))
+    cs_xy = np.cumsum(np.concatenate(([0], mjd_ref * flux)))
+
+    for i in range(n):
+        s = max(0, i - half_w)
+        e = min(n, i + half_w + 1)
+        w = e - s
+        if w < 2:
+            continue
+
+        sum_x = cs_x[e] - cs_x[s]
+        sum_y = cs_y[e] - cs_y[s]
+        sum_xx = cs_xx[e] - cs_xx[s]
+        sum_xy = cs_xy[e] - cs_xy[s]
+
+        denom = w * sum_xx - sum_x**2
+        grad[i] = (w * sum_xy - sum_x * sum_y) / denom if denom != 0 else 0
+
+    return grad
+
+
+def bin_light_curve(mjd, flux, fluxerr, bin_size=DEFAULT_BIN_SIZE_DAYS):
+    """O(N) vectorized light curve binning using np.bincount.
+
+    Returns (binned_times, binned_flux, binned_fluxerr).
+    """
+    bin_edges = np.arange(mjd.min(), mjd.max() + bin_size, bin_size)
+    bin_indices = np.digitize(mjd, bin_edges) - 1
+    num_bins = len(bin_edges)
+
+    wf = 1.0 / fluxerr**2
+    counts = np.bincount(bin_indices, minlength=num_bins)
+    sum_wf = np.bincount(bin_indices, weights=wf, minlength=num_bins)
+
+    valid = (counts > 0) & (sum_wf > 0)
+
+    b_t = np.bincount(bin_indices, weights=mjd, minlength=num_bins)[valid]
+    b_t /= counts[valid]
+    b_f = np.bincount(bin_indices, weights=flux * wf, minlength=num_bins)[valid]
+    b_f /= sum_wf[valid]
+    b_fe = np.sqrt(1.0 / sum_wf[valid])
+
+    return b_t, b_f, b_fe
+
+
+def detect_flares(
+    mjd,
+    flux,
+    peak_threshold=DEFAULT_PEAK_THRESHOLD,
+    smooth_window=DEFAULT_SMOOTH_WINDOW,
+    min_cluster_size=DEFAULT_MIN_CLUSTER_SIZE,
+    saddle_ratio=DEFAULT_SADDLE_RATIO,
+    region_threshold=DEFAULT_REGION_THRESHOLD,
+    max_gap=DEFAULT_MAX_GAP_DAYS,
+):
+    """Peak-first flare detection on a (binned) flux light curve.
+
+    Returns a list of regions, each a dict with keys
+    'start', 'end', 'peak_flux', 'significance'.
+    """
+    n_points = len(flux)
+    if n_points == 0:
+        return []
+
+    median_f = np.median(flux)
+    std_f = np.std(flux)
+
+    flux_threshold = median_f + peak_threshold * std_f
+
+    # Calculate smoothed gradient for expansion boundaries
+    grad = get_uneven_gradient(mjd, flux, window=smooth_window)
+
+    # Find local maxima on raw flux (to preserve peak sensitivity)
+    peaks = []
+    if n_points >= 2 and flux[0] > flux[1]:
+        peaks.append(0)
+    for i in range(1, n_points - 1):
+        if flux[i] > flux[i - 1] and flux[i] > flux[i + 1]:
+            peaks.append(i)
+    if n_points >= 2 and flux[-1] > flux[-2]:
+        peaks.append(n_points - 1)
+
+    peaks = [p for p in peaks if flux[p] > flux_threshold]
+    if not peaks:
+        return []
+
+    # BFS expansion using the smoothed gradient
+    assignments = np.full(n_points, -1)
+    frontiers = {p: {'left': p, 'right': p, 'active': True} for p in peaks}
+    for p in peaks:
+        assignments[p] = p
+
+    any_active = True
+    while any_active:
+        any_active = False
+        for p in peaks:
+            if not frontiers[p]['active']:
+                continue
+            expanded = False
+
+            # Expand LEFT: rise phase (moving backward in time). Stop if the
+            # point dips below the global median or the gap exceeds max_gap.
+            l = frontiers[p]['left']
+            if (
+                l > 0
+                and assignments[l - 1] == -1
+                and flux[l - 1] >= median_f
+                and (mjd[l] - mjd[l - 1]) <= max_gap
+            ):
+                if flux[l - 1] < flux[l]:
+                    assignments[l - 1] = p
+                    frontiers[p]['left'] = l - 1
+                    expanded = True
+                elif grad[l] >= 0:
+                    assignments[l - 1] = p
+                    frontiers[p]['left'] = l - 1
+                    expanded = True
+
+            # Expand RIGHT: decay phase (moving forward in time)
+            r = frontiers[p]['right']
+            if (
+                r < n_points - 1
+                and assignments[r + 1] == -1
+                and flux[r + 1] >= median_f
+                and (mjd[r + 1] - mjd[r]) <= max_gap
+            ):
+                if flux[r + 1] < flux[r]:
+                    assignments[r + 1] = p
+                    frontiers[p]['right'] = r + 1
+                    expanded = True
+                elif grad[r] <= 0:
+                    assignments[r + 1] = p
+                    frontiers[p]['right'] = r + 1
+                    expanded = True
+
+            if not expanded:
+                frontiers[p]['active'] = False
+            else:
+                any_active = True
+
+    # Build raw clusters
+    raw_clusters = []
+    for p in peaks:
+        l, r = frontiers[p]['left'], frontiers[p]['right']
+        if (r - l + 1) >= min_cluster_size:
+            raw_clusters.append({'start_idx': l, 'end_idx': r, 'peak_flux': flux[p]})
+
+    if not raw_clusters:
+        return []
+
+    # Saddle-point merging
+    merged_indices = [[raw_clusters[0]['start_idx'], raw_clusters[0]['end_idx']]]
+    curr_peak_f = raw_clusters[0]['peak_flux']
+    for i in range(1, len(raw_clusters)):
+        prev_s, prev_e = merged_indices[-1]
+        next_s, next_e = raw_clusters[i]['start_idx'], raw_clusters[i]['end_idx']
+        next_peak_f = raw_clusters[i]['peak_flux']
+
+        temporal_gap = mjd[next_s] - mjd[prev_e]
+        no_data_between = next_s <= prev_e + 1
+
+        if temporal_gap > max_gap:
+            # Large data void - always separate
+            merged_indices.append([next_s, next_e])
+            curr_peak_f = next_peak_f
+        elif no_data_between or next_s <= prev_e + 2:
+            # Adjacent or overlapping - always merge
+            merged_indices[-1][1] = next_e
+            curr_peak_f = max(curr_peak_f, next_peak_f)
+        else:
+            # True saddle exists between clusters
+            saddle_f = np.min(flux[prev_e + 1 : next_s])
+            is_shallow = (saddle_f - median_f) > (
+                saddle_ratio * (min(curr_peak_f, next_peak_f) - median_f)
+            )
+            if is_shallow:
+                merged_indices[-1][1] = next_e
+                curr_peak_f = max(curr_peak_f, next_peak_f)
+            else:
+                merged_indices.append([next_s, next_e])
+                curr_peak_f = next_peak_f
+
+    # Final gate: the region median must clear the global median by
+    # region_threshold sigma
+    support_threshold = median_f + region_threshold * std_f
+    flares = []
+    for s, e in merged_indices:
+        region_flux = flux[s : e + 1]
+        if np.median(region_flux) >= support_threshold:
+            flares.append(
+                {
+                    'start': mjd[s],
+                    'end': mjd[e],
+                    'peak_flux': np.max(region_flux),
+                    'significance': (np.max(region_flux) - median_f) / std_f,
+                }
+            )
+
+    return flares
+
+
+def calc_pdrs_stats(
+    tme,
+    bin_size_days=DEFAULT_BIN_SIZE_DAYS,
+    peak_threshold=DEFAULT_PEAK_THRESHOLD,
+    smooth_window=DEFAULT_SMOOTH_WINDOW,
+    min_cluster_size=DEFAULT_MIN_CLUSTER_SIZE,
+    saddle_ratio=DEFAULT_SADDLE_RATIO,
+    region_threshold=DEFAULT_REGION_THRESHOLD,
+    max_gap_days=DEFAULT_MAX_GAP_DAYS,
+):
+    """Compute PDRS flare features for a single (times, mags, magerrs) tuple.
+
+    Magnitudes are converted to flux relative to the median magnitude, so a
+    brightening (decreasing magnitude) appears as a flux increase.
+
+    Returns a dict with keys n_flares, flare_significance, flare_duty_cycle;
+    all NaN if the light curve has too few usable points.
+    """
+    t = np.asarray(tme[0], dtype=float)
+    mag = np.asarray(tme[1], dtype=float)
+    magerr = np.asarray(tme[2], dtype=float)
+
+    keep = np.isfinite(t) & np.isfinite(mag) & np.isfinite(magerr) & (magerr > 0)
+    t, mag, magerr = t[keep], mag[keep], magerr[keep]
+
+    if len(t) < max(4, min_cluster_size):
+        return _nan_stats()
+
+    order = np.argsort(t)
+    t, mag, magerr = t[order], mag[order], magerr[order]
+
+    flux = 10 ** (-0.4 * (mag - np.median(mag)))
+    fluxerr = 0.4 * np.log(10) * flux * magerr
+
+    b_t, b_f, _ = bin_light_curve(t, flux, fluxerr, bin_size=bin_size_days)
+
+    if len(b_t) < max(4, min_cluster_size):
+        return _nan_stats()
+
+    flares = detect_flares(
+        b_t,
+        b_f,
+        peak_threshold=peak_threshold,
+        smooth_window=smooth_window,
+        min_cluster_size=min_cluster_size,
+        saddle_ratio=saddle_ratio,
+        region_threshold=region_threshold,
+        max_gap=max_gap_days,
+    )
+
+    baseline = t[-1] - t[0]
+    if len(flares) == 0 or baseline <= 0:
+        return {'n_flares': 0, 'flare_significance': 0.0, 'flare_duty_cycle': 0.0}
+
+    total_flare_time = float(np.sum([f['end'] - f['start'] for f in flares]))
+
+    return {
+        'n_flares': len(flares),
+        'flare_significance': float(np.max([f['significance'] for f in flares])),
+        'flare_duty_cycle': min(total_flare_time / baseline, 1.0),
+    }

--- a/tools/featureGeneration/pdrs.py
+++ b/tools/featureGeneration/pdrs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """
-PDRS: peak-detection region segmentation for flare / high-activity features.
+PDRS: peak-driven region segmentation for flare / high-activity features.
+
+Adapted from https://github.com/zerozole/Peak_Driven_Region_Segmentation
 
 Detects flare regions in a light curve by finding significant peaks in binned
 flux, growing each peak into a region using a gradient-guided expansion,

--- a/tools/featureGeneration/pdrs.py
+++ b/tools/featureGeneration/pdrs.py
@@ -149,37 +149,37 @@ def detect_flares(
 
             # Expand LEFT: rise phase (moving backward in time). Stop if the
             # point dips below the global median or the gap exceeds max_gap.
-            l = frontiers[p]['left']
+            left = frontiers[p]['left']
             if (
-                l > 0
-                and assignments[l - 1] == -1
-                and flux[l - 1] >= median_f
-                and (mjd[l] - mjd[l - 1]) <= max_gap
+                left > 0
+                and assignments[left - 1] == -1
+                and flux[left - 1] >= median_f
+                and (mjd[left] - mjd[left - 1]) <= max_gap
             ):
-                if flux[l - 1] < flux[l]:
-                    assignments[l - 1] = p
-                    frontiers[p]['left'] = l - 1
+                if flux[left - 1] < flux[left]:
+                    assignments[left - 1] = p
+                    frontiers[p]['left'] = left - 1
                     expanded = True
-                elif grad[l] >= 0:
-                    assignments[l - 1] = p
-                    frontiers[p]['left'] = l - 1
+                elif grad[left] >= 0:
+                    assignments[left - 1] = p
+                    frontiers[p]['left'] = left - 1
                     expanded = True
 
             # Expand RIGHT: decay phase (moving forward in time)
-            r = frontiers[p]['right']
+            right = frontiers[p]['right']
             if (
-                r < n_points - 1
-                and assignments[r + 1] == -1
-                and flux[r + 1] >= median_f
-                and (mjd[r + 1] - mjd[r]) <= max_gap
+                right < n_points - 1
+                and assignments[right + 1] == -1
+                and flux[right + 1] >= median_f
+                and (mjd[right + 1] - mjd[right]) <= max_gap
             ):
-                if flux[r + 1] < flux[r]:
-                    assignments[r + 1] = p
-                    frontiers[p]['right'] = r + 1
+                if flux[right + 1] < flux[right]:
+                    assignments[right + 1] = p
+                    frontiers[p]['right'] = right + 1
                     expanded = True
-                elif grad[r] <= 0:
-                    assignments[r + 1] = p
-                    frontiers[p]['right'] = r + 1
+                elif grad[right] <= 0:
+                    assignments[right + 1] = p
+                    frontiers[p]['right'] = right + 1
                     expanded = True
 
             if not expanded:
@@ -190,9 +190,11 @@ def detect_flares(
     # Build raw clusters
     raw_clusters = []
     for p in peaks:
-        l, r = frontiers[p]['left'], frontiers[p]['right']
-        if (r - l + 1) >= min_cluster_size:
-            raw_clusters.append({'start_idx': l, 'end_idx': r, 'peak_flux': flux[p]})
+        left, right = frontiers[p]['left'], frontiers[p]['right']
+        if (right - left + 1) >= min_cluster_size:
+            raw_clusters.append(
+                {'start_idx': left, 'end_idx': right, 'peak_flux': flux[p]}
+            )
 
     if not raw_clusters:
         return []

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -27,7 +27,13 @@ import pandas as pd
 from astropy.coordinates import SkyCoord, angular_separation
 import astropy.units as u
 from datetime import datetime
-from tools.featureGeneration import periodsearch, alertstats, external_xmatch
+from tools.featureGeneration import (
+    periodsearch,
+    alertstats,
+    external_xmatch,
+    pdrs,
+    drw,
+)
 import warnings
 from cesium.featurize import time_series, featurize_single_ts
 import json
@@ -46,6 +52,8 @@ ext_catalog_info = config['feature_generation']['external_catalog_features']
 cesium_feature_list = config['feature_generation']['cesium_features']
 period_algorithms = config['feature_generation']['period_algorithms']
 path_to_features = config['feature_generation']['path_to_features']
+pdrs_params = config['feature_generation'].get('pdrs', {})
+drw_params = config['feature_generation'].get('drw', {})
 
 if path_to_features is not None:
     BASE_DIR = pathlib.Path(path_to_features)
@@ -510,6 +518,8 @@ def generate_features(
     dirname: str = 'generated_features',
     filename: str = 'gen_features',
     doCesium: bool = False,
+    doFlareDetection: bool = False,
+    doDRW: bool = False,
     doNotSave: bool = False,
     stop_early: bool = False,
     doQuadrantFile: bool = False,
@@ -553,6 +563,8 @@ def generate_features(
     :param dirname: name of generated feature directory (str)
     :param filename: prefix of each feature filename (str)
     :param doCesium: flag to compute config-specified cesium features in addition to default list (bool)
+    :param doFlareDetection: flag to compute PDRS flare/high-activity segmentation features (bool)
+    :param doDRW: flag to fit damped-random-walk models and compute DRW anomaly features (bool)
     :param doNotSave: flag to avoid saving generated features (bool)
     :param stop_early: flag to stop feature generation before entire quadrant is run. Pair with --limit to run small-scale tests (bool)
     :param doQuadrantFile: flag to use a generated file containing [jobID, field, ccd, quad] columns instead of specifying --field, --ccd and --quad (bool)
@@ -910,6 +922,23 @@ def generate_features(
     for idx, _id in enumerate(id_list_bs):
         for si, key in enumerate(stat_keys):
             feature_dict[_id][key] = float(basic_stats_arr[idx, si])
+
+    if doFlareDetection:
+        print(f'Computing PDRS flare features for {len(id_list_bs)} sources...')
+        for _id in id_list_bs:
+            feature_dict[_id].update(
+                pdrs.calc_pdrs_stats(tme_dict[_id]['tme'], **pdrs_params)
+            )
+
+    if doDRW:
+        print(f'Computing DRW features for {len(id_list_bs)} sources...')
+        drw_stats_list = drw.calc_drw_stats_batch(
+            [tme_dict[_id]['tme'] for _id in id_list_bs],
+            Ncore=Ncore,
+            **drw_params,
+        )
+        for _id, drw_stats in zip(id_list_bs, drw_stats_list):
+            feature_dict[_id].update(drw_stats)
 
     if baseline > 0:
         # Define frequency grid using largest LC time baseline
@@ -1594,6 +1623,18 @@ def get_parser(**kwargs):
         help="if set, use Cesium to generate additional features specified in config",
     )
     parser.add_argument(
+        "--doFlareDetection",
+        action='store_true',
+        default=False,
+        help="if set, compute PDRS flare/high-activity segmentation features",
+    )
+    parser.add_argument(
+        "--doDRW",
+        action='store_true',
+        default=False,
+        help="if set, fit damped-random-walk models and compute DRW anomaly features",
+    )
+    parser.add_argument(
         "--doNotSave",
         action='store_true',
         default=False,
@@ -1693,6 +1734,8 @@ def main():
         dirname=args.dirname,
         filename=args.filename,
         doCesium=args.doCesium,
+        doFlareDetection=args.doFlareDetection,
+        doDRW=args.doDRW,
         doNotSave=args.doNotSave,
         stop_early=args.stop_early,
         doQuadrantFile=args.doQuadrantFile,

--- a/tools/generate_features_slurm.py
+++ b/tools/generate_features_slurm.py
@@ -389,6 +389,8 @@ def main():
     dirname = args.dirname
     filename = args.filename
     doCesium = args.doCesium
+    doFlareDetection = args.doFlareDetection
+    doDRW = args.doDRW
     doNotSave = args.doNotSave
     stop_early = args.stop_early
     doSpecificIDs = args.doSpecificIDs
@@ -409,6 +411,10 @@ def main():
         extra_flags.append("--doRemoveTerrestrial")
     if doCesium:
         extra_flags.append("--doCesium")
+    if doFlareDetection:
+        extra_flags.append("--doFlareDetection")
+    if doDRW:
+        extra_flags.append("--doDRW")
     if doNotSave:
         extra_flags.append("--doNotSave")
     if stop_early:


### PR DESCRIPTION
# AGN / anomaly features for the SCoPe pipeline (`agn-features` branch)

## Motivation

SCoPe's feature engineering is tuned toward periodic and eclipsing variables.
This branch extends the feature set toward AGN and stochastic variability:
damped-random-walk (DRW) parameters, extreme-value-theory (EVT) anomaly
scores, and flare / high-activity segmentation. Light curves are thereby
marked for anomalies without touching any existing behavior: all new
features default to `include: false` (annotation-only), both new
feature-generation steps are behind opt-in flags, and no existing model,
feature file, or training set is affected.

Methods are adapted from two existing research codes:

- **PDRS** — (https://github.com/zerozole/Peak_Driven_Region_Segmentation) - peak-detection region segmentation of flares 
  (binned relative flux, gradient-guided region growing, saddle-point merging, region-median
  gate).
- **FLARE**  — (https://github.com/zerozole/FLARE) - DRW/OU baseline fitting
  with celerite and a peaks-over-threshold generalized Pareto calibration of
  the maximum standardized residual.

## What was added

| File | Change |
|---|---|
| `tools/featureGeneration/pdrs.py` | new: flare segmentation → `n_flares`, `flare_significance`, `flare_duty_cycle` |
| `tools/featureGeneration/drw.py` | new: celerite DRW/OU fit (RealTerm + JitterTerm, L-BFGS-B) → `drw_tau`, `drw_sigma`, `drw_max_z`, `drw_fit_success` |
| `tools/evt_calibration.py` | new: population-level GPD calibration → `anomaly_score`, `anomaly_flag` columns + frozen JSON calibration |
| `tools/generate_features.py` | `--doFlareDetection` / `--doDRW` flags (default off), computation hooked in after basic stats, hyperparameters read from config |
| `tools/generate_features_slurm.py` | forwards the two new flags |
| `config.defaults.yaml` | feature registration (`include: false`) + `feature_generation.pdrs/.drw/.evt` hyperparameter blocks |
| `requirements.txt`, `pyproject.toml` | `celerite>=0.4.2` dependency; `evt-calibration` console script |
| `tests/test_agn_features.py` | 22 synthetic-data tests (no Kowalski/GPU needed) |

`periodfind` is untouched.

## Method summary

**DRW features** (`--doDRW`): each light curve is fit with a celerite GP —
`RealTerm` (the DRW kernel; `sigma = sqrt(a)` is the asymptotic rms,
`tau = 1/c` the damping timescale) plus a `JitterTerm` absorbing
underestimated photometric errors — by maximizing the marginal likelihood
with L-BFGS-B. Standardized one-step-ahead residuals under the fitted OU
model give `drw_max_z`, the per-source anomaly statistic. A plain single
fit is the default (`max_iter: 1`); setting `max_iter > 1` enables FLARE's
iterative |z| > `z_thr` masking so flares don't contaminate their own
baseline. Note `SF_inf = sqrt(2) * drw_sigma` for comparison with the
quasar literature.

**PDRS features** (`--doFlareDetection`): magnitudes are converted to flux
relative to the median, binned (inverse-variance, 3-day bins), and searched
for peaks above `median + 2 sigma`; peaks are grown into regions with a
gradient-guided expansion, merged across shallow saddles, and gated on the
region median. Scalars: region count, max region significance, and the
fraction of the baseline spent in regions.

**EVT anomaly score** (`evt-calibration`, run after feature generation):
pools `drw_max_z` per filter, takes the 95th-percentile
peaks-over-threshold cut, fits a generalized Pareto distribution to the
exceedances (`floc=0`), and inverts it for a 1% target false-alarm rate.
`anomaly_score = -log10 P(max_z > z)`; `anomaly_flag = 1` above the
detection threshold. The calibration is frozen to JSON so later fields are
scored consistently. Dry-run by default; `--apply` writes the columns.

## Hyperparameters (defaults, tuned for ZTF DR23; all in config)

- `feature_generation.pdrs`: `bin_size_days: 3.0`, `peak_threshold: 2.0`,
  `smooth_window: 7`, `min_cluster_size: 3`, `saddle_ratio: 0.2`,
  `region_threshold: 0.5`, `max_gap_days: 60.0`
- `feature_generation.drw`: `min_epochs: 15`, `max_iter: 1`, `z_thr: 3.0`
- `feature_generation.evt`: `pot_percentile: 95.0`, `p_target: 0.01`

## Usage

```bash
generate-features --doFlareDetection --doDRW [usual arguments...]
evt-calibration --features-dir generated_features          # report only
evt-calibration --features-dir generated_features --apply  # write columns
```

## Testing

`python -m pytest tests/test_agn_features.py -v` — 22 tests, all passing:
DRW recovers known (tau, sigma) from exact OU simulations and its residuals
are ~N(0,1) under the true model; an injected flare raises `drw_max_z` from
~4 to ~9 and is flagged against a quiet DRW population after EVT
calibration; PDRS detects injected flares at significance > 10 versus < 4
on pure noise and keeps two well-separated flares as two regions; edge
cases (short curves, constant magnitudes, NaN handling, JSON round-trip)
are covered. The existing `tests/test_periodsearch.py` suite (87 tests)
still passes.

## Compatibility and later training use

Nothing needs retraining: all features are registered `include: false` and
both generation steps are opt-in. To use the features in classifiers later:
flip `include: true` in the config, regenerate features for the training
set with the flags on, rebuild the training set, and retrain (XGBoost
checks feature names and the DNN input width is fixed, so retraining is
mandatory at that point). Training, imputation, and inference all derive
feature lists from the config, so no further code changes are needed.

## Known caveats (candid notes for review)

- PDRS uses the light curve's *global* sigma both for the peak threshold
  and the region-median gate, so very active sources (several large flares)
  raise their own detection bar; in synthetic tests a multi-flare curve can
  gate out entirely while single flares are detected robustly. This is
  faithful to the original algorithm; if it matters for DR23,
  `region_threshold` is the knob to lower.
- With `max_iter: 1` (plain fit), flares slightly inflate their own DRW
  baseline, compressing the top of the `drw_max_z` scale; the EVT
  calibration is relative so ranking survives. `max_iter: 3` re-enables
  FLARE's masking at ~3x cost — worth an A/B check on a real field.
- AGN damping timescales near or above the survey baseline are poorly
  constrained (`drw_tau` saturates); `drw_max_z` / `anomaly_score` are the
  baseline-robust anomaly quantities.
