### PR TITLE
Rubin agn fixes

### DIFF
--- a/tests/test_agn_features.py
+++ b/tests/test_agn_features.py
@@ -228,11 +228,9 @@ class TestDRW:
                 else:
                     assert b[key] == s[key]
 
-
-# ---------------------------------------------------------------------------
-# TestEVT
-# ---------------------------------------------------------------------------
-
+    # ---------------------------------------------------------------------------
+    # TestEVT
+    # ---------------------------------------------------------------------------
 
     def test_unconstrained_fit_is_not_flagged_success(self):
         """A fit that runs to a parameter bound must not report success.
@@ -331,11 +329,9 @@ class TestEVT:
         with pytest.raises(ValueError):
             evt.fit_gpd(np.ones(10))
 
-
-# ---------------------------------------------------------------------------
-# End-to-end: DRW max_z of a flaring source stands out after calibration
-# ---------------------------------------------------------------------------
-
+    # ---------------------------------------------------------------------------
+    # End-to-end: DRW max_z of a flaring source stands out after calibration
+    # ---------------------------------------------------------------------------
 
     def test_detects_wide_and_long_layouts(self):
         """EVT must recognise the Rubin wide layout, not just the ZTF long one.
@@ -348,14 +344,17 @@ class TestEVT:
         filter.
         """
         wide_cols = [
-            '_id', 'n_g', 'drw_tau_g', 'drw_max_z_g', 'drw_max_z_r',
-            'drw_max_z_i', 'n_flares_g',
+            '_id',
+            'n_g',
+            'drw_tau_g',
+            'drw_max_z_g',
+            'drw_max_z_r',
+            'drw_max_z_i',
+            'n_flares_g',
         ]
         mapping, layout = evt.max_z_layout(wide_cols)
         assert layout == 'wide'
-        assert mapping == {
-            'g': 'drw_max_z_g', 'r': 'drw_max_z_r', 'i': 'drw_max_z_i'
-        }
+        assert mapping == {'g': 'drw_max_z_g', 'r': 'drw_max_z_r', 'i': 'drw_max_z_i'}
 
         long_cols = ['_id', 'filter', 'drw_tau', 'drw_max_z', 'n_flares']
         mapping, layout = evt.max_z_layout(long_cols)
@@ -370,18 +369,19 @@ class TestEVT:
         """A wide table must yield one calibration per band, not one pooled."""
         rng = np.random.default_rng(3)
         n = 400
-        frame = pd.DataFrame({
-            '_id': np.arange(n),
-            # deliberately different scales per band
-            'drw_max_z_g': np.abs(rng.normal(0.0, 1.0, n)) + 3.0,
-            'drw_max_z_r': np.abs(rng.normal(0.0, 2.0, n)) + 6.0,
-        })
+        frame = pd.DataFrame(
+            {
+                '_id': np.arange(n),
+                # deliberately different scales per band
+                'drw_max_z_g': np.abs(rng.normal(0.0, 1.0, n)) + 3.0,
+                'drw_max_z_r': np.abs(rng.normal(0.0, 2.0, n)) + 6.0,
+            }
+        )
         mapping, layout = evt.max_z_layout(frame.columns)
         assert layout == 'wide'
 
         calibs = {
-            band: evt.fit_gpd(frame[col].to_numpy())
-            for band, col in mapping.items()
+            band: evt.fit_gpd(frame[col].to_numpy()) for band, col in mapping.items()
         }
         assert set(calibs) == {'g', 'r'}
         # the r band sits higher, so its POT threshold must too

--- a/tests/test_agn_features.py
+++ b/tests/test_agn_features.py
@@ -233,6 +233,43 @@ class TestDRW:
 # ---------------------------------------------------------------------------
 
 
+    def test_unconstrained_fit_is_not_flagged_success(self):
+        """A fit that runs to a parameter bound must not report success.
+
+        scipy reports convergence even when the optimum sits against a
+        bound, so on a baseline too short to show the DRW turnover every
+        fit came back drw_fit_success = 1 with tau pinned at a rail. The
+        flag has to distinguish converged from constrained, or anything
+        filtering on it downstream gets meaningless tau and sigma.
+        """
+        # A pure white-noise curve: there is no damping timescale to find,
+        # so the fit has nothing to constrain tau with.
+        rng = np.random.default_rng(1)
+        n = 120
+        times = np.sort(rng.uniform(0.0, 200.0, n))
+        magerrs = np.full(n, 0.02)
+        mags = 20.0 + rng.normal(0.0, 0.02, n)
+
+        stats = drw.calc_drw_stats((times, mags, magerrs))
+
+        baseline = times[-1] - times[0]
+        constrained = drw._fit_is_constrained(
+            stats['drw_tau'], stats['drw_sigma'], times
+        )
+        assert stats['drw_fit_success'] == int(constrained)
+        if not constrained:
+            # the parameters are still reported, as limits
+            assert np.isfinite(stats['drw_tau'])
+            assert np.isfinite(stats['drw_max_z'])
+
+        # An explicitly out-of-range tau is never constrained
+        assert not drw._fit_is_constrained(10.0 * baseline, 0.1, times)
+        assert not drw._fit_is_constrained(1e-6, 0.1, times)
+        assert not drw._fit_is_constrained(0.5 * baseline, 1e-8, times)
+        # ... while a sane one is
+        assert drw._fit_is_constrained(0.1 * baseline, 0.1, times)
+
+
 class TestEVT:
     """Tests for the EVT (peaks-over-threshold / GPD) calibration."""
 

--- a/tests/test_agn_features.py
+++ b/tests/test_agn_features.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tools'))
 
 import json  # noqa: E402
 import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
 
 import pdrs  # noqa: E402
 import drw  # noqa: E402
@@ -334,6 +335,57 @@ class TestEVT:
 # ---------------------------------------------------------------------------
 # End-to-end: DRW max_z of a flaring source stands out after calibration
 # ---------------------------------------------------------------------------
+
+
+    def test_detects_wide_and_long_layouts(self):
+        """EVT must recognise the Rubin wide layout, not just the ZTF long one.
+
+        #586 wrote evt_calibration.py against the ZTF feature tables: one row
+        per source-band, a single drw_max_z column, and a filter column to
+        group on. #587 emits one row per source with drw_max_z_<band>, so
+        the tool matched no files and exited without scoring anything. Both
+        layouts have to resolve, and the long path must keep grouping by
+        filter.
+        """
+        wide_cols = [
+            '_id', 'n_g', 'drw_tau_g', 'drw_max_z_g', 'drw_max_z_r',
+            'drw_max_z_i', 'n_flares_g',
+        ]
+        mapping, layout = evt.max_z_layout(wide_cols)
+        assert layout == 'wide'
+        assert mapping == {
+            'g': 'drw_max_z_g', 'r': 'drw_max_z_r', 'i': 'drw_max_z_i'
+        }
+
+        long_cols = ['_id', 'filter', 'drw_tau', 'drw_max_z', 'n_flares']
+        mapping, layout = evt.max_z_layout(long_cols)
+        assert layout == 'long'
+        assert mapping == {'all': 'drw_max_z'}
+
+        mapping, layout = evt.max_z_layout(['_id', 'median', 'wstd'])
+        assert layout is None
+        assert mapping == {}
+
+    def test_wide_layout_calibrates_each_band_separately(self):
+        """A wide table must yield one calibration per band, not one pooled."""
+        rng = np.random.default_rng(3)
+        n = 400
+        frame = pd.DataFrame({
+            '_id': np.arange(n),
+            # deliberately different scales per band
+            'drw_max_z_g': np.abs(rng.normal(0.0, 1.0, n)) + 3.0,
+            'drw_max_z_r': np.abs(rng.normal(0.0, 2.0, n)) + 6.0,
+        })
+        mapping, layout = evt.max_z_layout(frame.columns)
+        assert layout == 'wide'
+
+        calibs = {
+            band: evt.fit_gpd(frame[col].to_numpy())
+            for band, col in mapping.items()
+        }
+        assert set(calibs) == {'g', 'r'}
+        # the r band sits higher, so its POT threshold must too
+        assert calibs['r']['u'] > calibs['g']['u']
 
 
 class TestEndToEnd:

--- a/tools/evt_calibration.py
+++ b/tools/evt_calibration.py
@@ -11,6 +11,11 @@ a generalized Pareto distribution (GPD) to the tail via peaks-over-threshold
     anomaly_flag   1 if drw_max_z exceeds the detection threshold derived
                    from the target false-alarm rate, else 0
 
+Handles both feature layouts: the ZTF long form (one row per source-band with
+a single drw_max_z and a filter column) and the Rubin wide form (one row per
+source with drw_max_z_<band> per band), writing anomaly_score_<band> and
+anomaly_flag_<band> in the latter case.
+
 Calibration is performed per filter (per ZTF band) by default and saved to a
 JSON file so that later runs can score new sources against the same frozen
 threshold. By default the tool only reports; pass --apply to write the
@@ -131,15 +136,45 @@ def anomaly_score(z, calib):
     return score
 
 
+BANDS = ('u', 'g', 'r', 'i', 'z', 'y')
+
+
+def max_z_layout(columns):
+    """Identify how drw_max_z is stored in a feature table.
+
+    Two layouts exist in scope-ml:
+
+    long (ZTF, #586)
+        one row per source-band; a single ``drw_max_z`` column plus a
+        ``filter`` column identifying the band.
+    wide (Rubin, #587)
+        one row per source; ``drw_max_z_<band>`` for each band, because
+        Rubin features are computed per band to avoid chromatic offsets.
+
+    Returns ``(mapping, layout)`` where mapping is {group_key: column} and
+    layout is 'wide', 'long' or None.
+    """
+    cols = set(columns)
+    per_band = {b: f'drw_max_z_{b}' for b in BANDS if f'drw_max_z_{b}' in cols}
+    if per_band:
+        return per_band, 'wide'
+    if 'drw_max_z' in cols:
+        return {'all': 'drw_max_z'}, 'long'
+    return {}, None
+
+
 def collect_feature_files(features_dir, pattern):
     paths = sorted(pathlib.Path(features_dir).rglob(pattern))
     usable = []
     for path in paths:
         try:
-            columns = pd.read_parquet(path, columns=['drw_max_z']).columns
+            import pyarrow.parquet as pq
+
+            columns = pq.ParquetFile(path).schema_arrow.names
         except Exception:
             continue
-        if 'drw_max_z' in columns:
+        mapping, _ = max_z_layout(columns)
+        if mapping:
             usable.append(path)
     return usable
 
@@ -223,17 +258,35 @@ def main():
     frames = [pd.read_parquet(path) for path in paths]
     pooled = pd.concat(frames, ignore_index=True)
 
-    per_filter = (not args.no_per_filter) and ('filter' in pooled.columns)
-    if per_filter:
-        groups = {
-            int(flt): grp['drw_max_z'].values for flt, grp in pooled.groupby('filter')
-        }
+    colmap, layout = max_z_layout(pooled.columns)
+    if layout == 'wide':
+        # One calibration per band. Pooling bands would mix different
+        # photometric depths into a single tail fit.
+        if args.no_per_filter:
+            stacked = np.concatenate(
+                [pooled[c].values.astype(float) for c in colmap.values()]
+            )
+            groups = {'all': stacked}
+            per_filter = False
+        else:
+            groups = {b: pooled[c].values.astype(float) for b, c in colmap.items()}
+            per_filter = True
     else:
-        groups = {'all': pooled['drw_max_z'].values}
+        per_filter = (not args.no_per_filter) and ('filter' in pooled.columns)
+        if per_filter:
+            groups = {
+                int(flt): grp['drw_max_z'].values
+                for flt, grp in pooled.groupby('filter')
+            }
+        else:
+            groups = {'all': pooled['drw_max_z'].values}
+
+    print(f"Feature layout: {layout} ({len(colmap)} max_z column(s))")
 
     calibration = {
         'p_target': p_target,
         'per_filter': per_filter,
+        'layout': layout,
         'groups': {},
     }
 
@@ -273,6 +326,24 @@ def main():
         return
 
     for path, df in zip(paths, frames):
+        if layout == 'wide':
+            # Per-band columns mirror the feature naming: anomaly_score_g etc.
+            for band, col in colmap.items():
+                calib = calibration['groups'].get(str(band))
+                if calib is None or col not in df.columns:
+                    continue
+                z = df[col].values.astype(float)
+                finite = np.isfinite(z)
+                band_flag = np.full(z.shape, np.nan)
+                band_flag[finite] = (
+                    z[finite] > calib['detection_threshold']
+                ).astype(float)
+                df[f'anomaly_score_{band}'] = anomaly_score(z, calib)
+                df[f'anomaly_flag_{band}'] = band_flag
+            df.to_parquet(path, index=False)
+            print(f"Updated {path}")
+            continue
+
         score = np.full(len(df), np.nan)
         flag = np.full(len(df), np.nan)
 

--- a/tools/evt_calibration.py
+++ b/tools/evt_calibration.py
@@ -335,9 +335,9 @@ def main():
                 z = df[col].values.astype(float)
                 finite = np.isfinite(z)
                 band_flag = np.full(z.shape, np.nan)
-                band_flag[finite] = (
-                    z[finite] > calib['detection_threshold']
-                ).astype(float)
+                band_flag[finite] = (z[finite] > calib['detection_threshold']).astype(
+                    float
+                )
                 df[f'anomaly_score_{band}'] = anomaly_score(z, calib)
                 df[f'anomaly_flag_{band}'] = band_flag
             df.to_parquet(path, index=False)

--- a/tools/featureGeneration/drw.py
+++ b/tools/featureGeneration/drw.py
@@ -37,7 +37,61 @@ LOG_A_BOUNDS = (np.log(1e-8), np.log(1e2))  # process variance (mag^2)
 LOG_C_BOUNDS = (np.log(1e-5), np.log(1e2))  # inverse timescale (1/day)
 LOG_JITTER_BOUNDS = (np.log(1e-6), np.log(1e1))  # extra white noise (mag)
 
+#: tau longer than this multiple of the baseline is treated as unresolved.
+#: 1.0 is the weakest defensible cut - a timescale longer than the observing
+#: window cannot be measured at all. The AGN literature is stricter (unbiased
+#: tau recovery is usually quoted as needing baseline > ~10 tau), so 0.1 is the
+#: conservative choice if you care about tau as a physical quantity rather than
+#: as a nuisance parameter.
+DEFAULT_TAU_MAX_BASELINE_FRAC = 1.0
+
 DRW_FEATURE_KEYS = ['drw_tau', 'drw_sigma', 'drw_max_z', 'drw_fit_success']
+
+
+def _fit_is_constrained(tau, sigma, t, tau_max_baseline_frac=None):
+    """Did the data actually determine tau and sigma, or did the fit run to a bound?
+
+    ``scipy``'s convergence flag says only that the minimiser terminated; it
+    reports success just as happily when the optimum sits against a parameter
+    bound. On a 257-day Rubin DP2 baseline that happens for most objects: tau
+    piles up at both rails (0.01 d and 1e5 d) and sigma collapses onto its
+    floor while the jitter term absorbs the variance. Those fits converged,
+    but their parameters carry no information, and anything downstream that
+    filters on ``drw_fit_success`` would otherwise treat them as trustworthy.
+
+    Unconstrained when any of:
+
+    * tau exceeds the baseline (the window cannot show the turnover),
+    * tau falls below the median sampling interval (nothing resolves it),
+    * sigma sits on its lower bound (the DRW term has no amplitude left).
+
+    Note this is a statement about *identifiability*, not fit quality - a
+    rail value is still meaningful as a limit, so tau and sigma are returned
+    unchanged and only the flag is lowered.
+    """
+    if not (np.isfinite(tau) and np.isfinite(sigma)) or tau <= 0:
+        return False
+
+    frac = (
+        DEFAULT_TAU_MAX_BASELINE_FRAC
+        if tau_max_baseline_frac is None
+        else tau_max_baseline_frac
+    )
+
+    baseline = float(t[-1] - t[0])
+    if baseline <= 0 or tau > frac * baseline:
+        return False
+
+    if len(t) > 1:
+        cadence = float(np.median(np.diff(t)))
+        if cadence > 0 and tau < cadence:
+            return False
+
+    sigma_floor = np.sqrt(np.exp(LOG_A_BOUNDS[0]))
+    if sigma <= sigma_floor * 1.01:
+        return False
+
+    return True
 
 
 def _nan_stats():
@@ -137,6 +191,7 @@ def calc_drw_stats(
     min_epochs=DEFAULT_MIN_EPOCHS,
     max_iter=DEFAULT_MAX_ITER,
     z_thr=DEFAULT_Z_THR,
+    tau_max_baseline_frac=None,
 ):
     """Compute DRW features for a single (times, mags, magerrs) tuple.
 
@@ -148,6 +203,11 @@ def calc_drw_stats(
     Returns a dict with keys drw_tau, drw_sigma, drw_max_z, drw_fit_success.
     Values are NaN (and drw_fit_success = 0) when the light curve is too
     short or the fit fails.
+
+    drw_fit_success means the optimiser converged AND the data constrained
+    the parameters - see _fit_is_constrained. tau and sigma are reported
+    even when the flag is 0, where a rail value should be read as a limit
+    rather than an estimate.
     """
     t = np.asarray(tme[0], dtype=float)
     y = np.asarray(tme[1], dtype=float)
@@ -183,11 +243,14 @@ def calc_drw_stats(
             break
 
         z = ou_resid(t, y, yerr, tau, sigma, mu, jitter)
+        constrained = _fit_is_constrained(
+            tau, sigma, t[ix], tau_max_baseline_frac=tau_max_baseline_frac
+        )
         result = {
             'drw_tau': float(tau),
             'drw_sigma': float(sigma),
             'drw_max_z': float(np.max(np.abs(z))),
-            'drw_fit_success': int(success),
+            'drw_fit_success': int(bool(success) and constrained),
         }
 
         new_mask = np.abs(z) > z_thr

--- a/tools/generate_features.py
+++ b/tools/generate_features.py
@@ -10,7 +10,7 @@ except Exception:
     get_ids_loop = None
     get_field_ids = None
 
-from scope.fritz import get_lightcurves_via_ids
+from scope.surveys.fritz import get_lightcurves_via_ids
 from scope.utils import (
     TychoBVfromGaia,
     exclude_radius,

--- a/tools/get_rubin_ids.py
+++ b/tools/get_rubin_ids.py
@@ -11,7 +11,7 @@ import os
 import pathlib
 import pandas as pd
 from scope.utils import parse_load_config
-from scope.rubin import make_rubin_client
+from scope.surveys.rubin import make_rubin_client
 
 BASE_DIR = pathlib.Path.cwd()
 config = parse_load_config()

--- a/tools/run_scope_local.py
+++ b/tools/run_scope_local.py
@@ -5,7 +5,7 @@ import os
 from datetime import datetime
 import pandas as pd
 from penquins import Kowalski
-from scope.fritz import get_lightcurves_via_ids, radec_to_iau_name
+from scope.surveys.fritz import get_lightcurves_via_ids, radec_to_iau_name
 from tools.get_quad_ids import get_cone_ids
 from scope.utils import (
     read_parquet,

--- a/tools/scope_download_classification.py
+++ b/tools/scope_download_classification.py
@@ -3,7 +3,7 @@ import argparse
 import pathlib
 import pandas as pd
 import pkg_resources
-from scope.fritz import api
+from scope.surveys.fritz import api
 from scope.utils import (
     read_hdf,
     write_hdf,

--- a/tools/scope_download_gcn_sources.py
+++ b/tools/scope_download_gcn_sources.py
@@ -6,7 +6,7 @@ from penquins import Kowalski
 from datetime import datetime, timedelta
 import numpy as np
 import json
-from scope.fritz import api
+from scope.surveys.fritz import api
 from tools.get_quad_ids import get_cone_ids
 from scope.utils import write_parquet, parse_load_config
 

--- a/tools/scope_manage_annotation.py
+++ b/tools/scope_manage_annotation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import pandas as pd
-from scope.fritz import api
+from scope.surveys.fritz import api
 
 
 def manage_annotation(action, source, group_ids, origin, key, value):

--- a/tools/scope_upload_classification.py
+++ b/tools/scope_upload_classification.py
@@ -3,7 +3,7 @@ import argparse
 import json as JSON
 import pandas as pd
 from penquins import Kowalski
-from scope.fritz import save_newsource, api, radec_to_iau_name
+from scope.surveys.fritz import save_newsource, api, radec_to_iau_name
 from scope.utils import (
     read_hdf,
     read_parquet,

--- a/tools/scope_upload_disagreements.py
+++ b/tools/scope_upload_disagreements.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from penquins import Kowalski
 import numpy as np
-from scope.fritz import get_highscoring_objects, get_stats
+from scope.surveys.fritz import get_highscoring_objects, get_stats
 import argparse
 import csv
 import json


### PR DESCRIPTION
# Fix three defects in the Rubin AGN feature path

All three were found by running the merged AGN features (#586 ZTF, #587 Rubin) on real Rubin
DP1 and DP2 data. None was reachable by the existing tests — the suite was green with all
three present.

---

## 1. Eight scripts in `tools/` have been broken since April

Commit `7887aa6` ("Include WISE as an option") moved `scope/{rubin,fritz,kowalski,wise}.py`
into `scope/surveys/`, but the importers were not updated, so these scripts raise
`ModuleNotFoundError` at import:

`generate_features.py`, `get_rubin_ids.py` (and therefore `generate_features_rubin.py`, which
imports it), `run_scope_local.py`, `scope_download_classification.py`,
`scope_download_gcn_sources.py`, `scope_manage_annotation.py`,
`scope_upload_classification.py`, `scope_upload_disagreements.py`.

One line per file; every symbol exists unchanged at the new path.

```python
-from scope.fritz import get_lightcurves_via_ids
+from scope.surveys.fritz import get_lightcurves_via_ids
```

---

## 2. EVT calibration could not consume Rubin features at all

`tools/evt_calibration.py` came from the ZTF path, where feature tables are **long** — one row
per source-band, a single `drw_max_z` column, and a `filter` column to group on. #587 emits
**wide** — one row per source with `drw_max_z_<band>` per band, because Rubin features are
computed per band to avoid chromatic offsets.

So `collect_feature_files()` matched nothing and the tool exited reporting that no feature
files with a `drw_max_z` column were found. **Anomaly scoring — the step that makes this an
anomaly detector — has never run on any Rubin output.** Neither PR was wrong on its own;
nothing tested the seam between them.

### Change

`max_z_layout(columns)` returns `({group_key: column}, layout)` and detects either form. In the
wide case the tool fits one GPD per band and writes `anomaly_score_<band>` /
`anomaly_flag_<band>`, mirroring the feature naming; `--no-per-filter` pools bands. The long
path is unchanged, and `layout` is recorded in the calibration JSON.

`collect_feature_files()` now reads the parquet schema via `pyarrow` instead of trying to read
one named column, so it can detect a layout without knowing the name in advance.

### Verified on real data

DP1, 586 sources:

```
Feature layout: wide (6 max_z column(s))
Group u: calibration failed (0 finite max_z values); skipping.
Group g: n=586 u=9.525 shape=-0.187 threshold=13.571 flagged=5 (0.85%)
Group r: n=586 u=9.412 shape=-0.080 threshold=12.422 flagged=6 (1.02%)
Group i: n=579 u=8.606 shape=-0.079 threshold=11.574 flagged=7 (1.21%)
Group z: n=567 u=8.016 shape=+0.082 threshold=10.734 flagged=7 (1.23%)
Group y: calibration failed (0 finite max_z values); skipping.
```

u and y fail because no DP1 source reaches DRW's `min_epochs = 15` in those bands — a property
of DP1, correctly reported rather than silently producing a threshold. On DP2 (20,546 sources)
all six bands calibrate, including u, and every band's flagged fraction lands on
`p_target = 0.01`.

---

## 3. `drw_fit_success` reported optimiser convergence, not constrainability

`fit_drw()` returned scipy's `r.success`, which reports success just as happily when the
optimum sits against a parameter bound. On DP2 that is most objects: against a 257-day
baseline, τ piles up at **both** rails (0.01 d and 1e5 d) and σ collapses onto its floor while
the `JitterTerm` absorbs the variance.

On a 20,546-object DP2 sample the flag was **1 for 100% of fits**, so anything filtering on it
downstream received τ values of tens of thousands of days as though they were measurements.

### Change

`_fit_is_constrained(tau, sigma, t)` additionally requires that the data determined the
parameters:

- τ within the baseline (the window cannot show a longer turnover),
- τ above the median sampling interval (nothing resolves it below that),
- σ off its lower bound (the DRW term has amplitude left).

`drw_fit_success = int(success and constrained)`.

**`drw_tau` and `drw_sigma` are still reported when the flag is 0.** A value at a rail is
meaningful as a *limit*, so replacing it with NaN would discard information. The threshold is
exposed as `tau_max_baseline_frac` (default `1.0`, the weakest defensible cut; the AGN
literature is stricter, and `0.1` is the conservative choice if τ is wanted as a physical
quantity).

This is a labelling change — **no feature values move**. On a DP2 sample the flag goes from
100% to 77%, the excluded set having median τ = 3,190 d and σ = 1.0e-04 against τ = 3.9 d and
σ = 0.037 for those kept.

### What this does *not* fix

τ being unconstrained is a property of the baseline, not of the fitting. Capping the jitter
term made the likelihood worse, and multi-start optimisation over τ initialisations spanning
`baseline/50` to `5 × baseline` moved the constrained fraction by 1% with a median likelihood
gain of zero. The likelihood is genuinely flat in τ. This change makes that visible instead of
hiding it behind a success flag.

---

## Testing

Three tests added:

- `TestDRW::test_unconstrained_fit_is_not_flagged_success` — fails without the flag fix
- `TestEVT::test_detects_wide_and_long_layouts` — pins both layouts and the no-match case
- `TestEVT::test_wide_layout_calibrates_each_band_separately` — a wide table gives one
  calibration per band, with the higher-scale band getting the higher POT threshold

